### PR TITLE
[BugFix] adapt vllm-ascend branch v0.21.0rc1, fix total_tokens=0 of o…

### DIFF
--- a/ascend_vllm/patch/platform/patch_disable_completion_tokens_details.py
+++ b/ascend_vllm/patch/platform/patch_disable_completion_tokens_details.py
@@ -1,10 +1,37 @@
 import importlib
 
+from vllm.entrypoints.openai.chat_completion import protocol as chat_protocol
 from vllm.entrypoints.openai.chat_completion import serving as chat_serving
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.engine import protocol as engine_protocol
 
 importlib.import_module("vllm_ascend.patch.platform.patch_minimax_usage_accounting")
+
+
+class UsageInfo(engine_protocol.OpenAIBaseModel):
+    prompt_tokens: int = 0
+    total_tokens: int = 0
+    completion_tokens: int | None = 0
+    prompt_tokens_details: engine_protocol.PromptTokenUsageInfo | None = None
+
+
+UsageInfo.__module__ = engine_protocol.__name__
+engine_protocol.UsageInfo = UsageInfo
+chat_protocol.UsageInfo = UsageInfo
+chat_serving.UsageInfo = UsageInfo
+
+
+def _rebuild_model_field(model_cls, field_name: str, annotation) -> None:
+    if not hasattr(model_cls, "model_fields") or field_name not in model_cls.model_fields:
+        return
+    model_cls.__annotations__[field_name] = annotation
+    model_cls.model_fields[field_name].annotation = annotation
+    model_cls.model_rebuild(force=True)
+
+
+_rebuild_model_field(chat_protocol.ChatCompletionResponse, "usage", UsageInfo)
+_rebuild_model_field(chat_protocol.ChatCompletionStreamResponse, "usage", UsageInfo | None)
+_rebuild_model_field(engine_protocol.RequestResponseMetadata, "final_usage_info", UsageInfo | None)
 
 
 def _make_usage_info_without_completion_details(
@@ -18,11 +45,11 @@ def _make_usage_info_without_completion_details(
     usage = engine_protocol.UsageInfo(
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
-        num_cached_tokens=num_cached_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
     )
 
-    if self.enable_prompt_tokens_details and num_cached_tokens:
-        usage.prompt_token_details = chat_serving.PromptTokenUsageInfo(
+    if self.enable_prompt_tokens_details and num_cached_tokens is not None:
+        usage.prompt_tokens_details = chat_serving.PromptTokenUsageInfo(
             cached_tokens=num_cached_tokens,
         )
 
@@ -41,7 +68,6 @@ if "_inject_stream_usage_details" in stream_gen.__globals__:
 
 full_gen = OpenAIServingChat.chat_completion_full_generator
 if "_make_full_response_usage" in full_gen.__globals__:
-    old_make_full_response_usage = full_gen.__globals__["_make_full_response_usage"]
 
     def _make_full_response_usage_without_completion_details(self, state):
         if state.final_res is None:

--- a/tests/patch/platform/test_disable_completion_tokens_details.py
+++ b/tests/patch/platform/test_disable_completion_tokens_details.py
@@ -5,13 +5,54 @@ import sys
 import types
 import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
-from pydantic import BaseModel, ConfigDict
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parents[3]
 PATCH_PATH = ROOT / "ascend_vllm" / "patch" / "platform" / "patch_disable_completion_tokens_details.py"
+
+
+class _Field:
+    def __init__(self, annotation: Any) -> None:
+        self.annotation = annotation
+
+
+class _BaseModel:
+    model_fields: ClassVar[dict[str, _Field]]
+
+    def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
+        cls.model_fields = {
+            name: _Field(annotation) for name, annotation in getattr(cls, "__annotations__", {}).items()
+        }
+
+    def __init__(self, **kwargs: Any) -> None:
+        for name in self.model_fields:
+            if name in kwargs:
+                setattr(self, name, kwargs.pop(name))
+            elif hasattr(type(self), name):
+                setattr(self, name, getattr(type(self), name))
+
+        for name, value in kwargs.items():
+            setattr(self, name, value)
+
+    @classmethod
+    def model_rebuild(cls, *, force: bool = False) -> bool:
+        return force
+
+    def model_dump(self) -> dict[str, Any]:
+        return {name: self._dump_value(getattr(self, name)) for name in self.model_fields if hasattr(self, name)}
+
+    @classmethod
+    def _dump_value(cls, value: Any) -> Any:
+        if isinstance(value, _BaseModel):
+            return value.model_dump()
+        if isinstance(value, list):
+            return [cls._dump_value(item) for item in value]
+        if isinstance(value, dict):
+            return {key: cls._dump_value(item) for key, item in value.items()}
+        return value
 
 
 def _make_package(name: str) -> types.ModuleType:
@@ -30,8 +71,8 @@ def _install_vllm_stubs(monkeypatch: pytest.MonkeyPatch) -> type[Any]:
     engine = _make_package("vllm.entrypoints.openai.engine")
     protocol = types.ModuleType("vllm.entrypoints.openai.engine.protocol")
 
-    class OpenAIBaseModel(BaseModel):
-        model_config = ConfigDict(extra="allow")
+    class OpenAIBaseModel(_BaseModel):
+        pass
 
     class PromptTokenUsageInfo(OpenAIBaseModel):
         cached_tokens: int | None = None
@@ -48,7 +89,7 @@ def _install_vllm_stubs(monkeypatch: pytest.MonkeyPatch) -> type[Any]:
     class ChatCompletionStreamResponse(OpenAIBaseModel):
         usage: UsageInfo | None = None
 
-    class RequestResponseMetadata(BaseModel):
+    class RequestResponseMetadata(_BaseModel):
         final_usage_info: UsageInfo | None = None
 
     class OriginalUsageInfo:

--- a/tests/patch/platform/test_disable_completion_tokens_details.py
+++ b/tests/patch/platform/test_disable_completion_tokens_details.py
@@ -8,8 +8,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from pydantic import BaseModel, ConfigDict
 
-ROOT = Path(__file__).resolve().parents[3]
+ROOT = Path(__file__).resolve().parents[2]
 PATCH_PATH = ROOT / "ascend_vllm" / "patch" / "platform" / "patch_disable_completion_tokens_details.py"
 
 
@@ -24,27 +25,48 @@ def _install_vllm_stubs(monkeypatch: pytest.MonkeyPatch) -> type[Any]:
     entrypoints = _make_package("vllm.entrypoints")
     openai = _make_package("vllm.entrypoints.openai")
     chat_completion = _make_package("vllm.entrypoints.openai.chat_completion")
+    chat_protocol = types.ModuleType("vllm.entrypoints.openai.chat_completion.protocol")
     chat_serving = types.ModuleType("vllm.entrypoints.openai.chat_completion.serving")
     engine = _make_package("vllm.entrypoints.openai.engine")
     protocol = types.ModuleType("vllm.entrypoints.openai.engine.protocol")
 
-    class UsageInfo:
+    class OpenAIBaseModel(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+    class PromptTokenUsageInfo(OpenAIBaseModel):
+        cached_tokens: int | None = None
+
+    class UsageInfo(OpenAIBaseModel):
+        prompt_tokens: int = 0
+        total_tokens: int = 0
+        completion_tokens: int | None = 0
+        prompt_tokens_details: PromptTokenUsageInfo | None = None
+
+    class ChatCompletionResponse(OpenAIBaseModel):
+        usage: UsageInfo | None = None
+
+    class ChatCompletionStreamResponse(OpenAIBaseModel):
+        usage: UsageInfo | None = None
+
+    class RequestResponseMetadata(BaseModel):
+        final_usage_info: UsageInfo | None = None
+
+    class OriginalUsageInfo:
         def __init__(
             self,
             *,
             prompt_tokens: int,
             completion_tokens: int,
-            num_cached_tokens: int | None = None,
+            total_tokens: int,
         ) -> None:
             self.prompt_tokens = prompt_tokens
             self.completion_tokens = completion_tokens
-            self.num_cached_tokens = num_cached_tokens
+            self.total_tokens = total_tokens
 
-    class PromptTokenUsageInfo:
-        def __init__(self, *, cached_tokens: int) -> None:
-            self.cached_tokens = cached_tokens
-
-    vars(chat_serving)["UsageInfo"] = UsageInfo
+    vars(chat_protocol)["UsageInfo"] = UsageInfo
+    vars(chat_protocol)["ChatCompletionResponse"] = ChatCompletionResponse
+    vars(chat_protocol)["ChatCompletionStreamResponse"] = ChatCompletionStreamResponse
+    vars(chat_serving)["UsageInfo"] = OriginalUsageInfo
     exec(
         """
 def _inject_stream_usage_details(data, state):
@@ -55,7 +77,7 @@ def _make_full_response_usage(self, state):
     return UsageInfo(
         prompt_tokens=-1,
         completion_tokens=-1,
-        num_cached_tokens=None,
+        total_tokens=-2,
     )
 
 
@@ -72,12 +94,20 @@ class OpenAIServingChat:
     )
 
     vars(chat_serving)["PromptTokenUsageInfo"] = PromptTokenUsageInfo
+    vars(protocol)["OpenAIBaseModel"] = OpenAIBaseModel
+    vars(protocol)["PromptTokenUsageInfo"] = PromptTokenUsageInfo
     vars(protocol)["UsageInfo"] = UsageInfo
+    vars(protocol)["RequestResponseMetadata"] = RequestResponseMetadata
 
     monkeypatch.setitem(sys.modules, "vllm", vllm)
     monkeypatch.setitem(sys.modules, "vllm.entrypoints", entrypoints)
     monkeypatch.setitem(sys.modules, "vllm.entrypoints.openai", openai)
     monkeypatch.setitem(sys.modules, "vllm.entrypoints.openai.chat_completion", chat_completion)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.entrypoints.openai.chat_completion.protocol",
+        chat_protocol,
+    )
     monkeypatch.setitem(sys.modules, "vllm.entrypoints.openai.chat_completion.serving", chat_serving)
     monkeypatch.setitem(sys.modules, "vllm.entrypoints.openai.engine", engine)
     monkeypatch.setitem(sys.modules, "vllm.entrypoints.openai.engine.protocol", protocol)
@@ -90,7 +120,11 @@ class OpenAIServingChat:
     monkeypatch.setitem(sys.modules, "vllm_ascend", vllm_ascend)
     monkeypatch.setitem(sys.modules, "vllm_ascend.patch", vllm_ascend_patch)
     monkeypatch.setitem(sys.modules, "vllm_ascend.patch.platform", vllm_ascend_patch_platform)
-    monkeypatch.setitem(sys.modules, "vllm_ascend.patch.platform.patch_minimax_usage_accounting", minimax_patch)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm_ascend.patch.platform.patch_minimax_usage_accounting",
+        minimax_patch,
+    )
 
     return chat_serving.__dict__["OpenAIServingChat"]
 
@@ -124,12 +158,21 @@ def test_make_usage_info_drops_completion_details_and_keeps_prompt_cache(
 
     assert usage.prompt_tokens == 11
     assert usage.completion_tokens == 7
-    assert usage.num_cached_tokens == 3
-    assert usage.prompt_token_details.cached_tokens == 3
+    assert usage.total_tokens == 18
+    assert usage.prompt_tokens_details.cached_tokens == 3
+    assert not hasattr(usage, "num_cached_tokens")
     assert not hasattr(usage, "completion_tokens_details")
 
+    payload = module.chat_protocol.ChatCompletionResponse(usage=usage).model_dump()
+    assert payload["usage"] == {
+        "prompt_tokens": 11,
+        "total_tokens": 18,
+        "completion_tokens": 7,
+        "prompt_tokens_details": {"cached_tokens": 3},
+    }
 
-def test_make_usage_info_omits_prompt_details_when_cache_is_empty(
+
+def test_make_usage_info_keeps_zero_cached_prompt_details(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module = _load_patch_module(monkeypatch)
@@ -142,7 +185,8 @@ def test_make_usage_info_omits_prompt_details_when_cache_is_empty(
         num_cached_tokens=0,
     )
 
-    assert not hasattr(usage, "prompt_token_details")
+    assert usage.total_tokens == 18
+    assert usage.prompt_tokens_details.cached_tokens == 0
     assert not hasattr(usage, "completion_tokens_details")
 
 
@@ -174,7 +218,8 @@ def test_full_response_usage_uses_basic_usage_without_completion_details(
 
     assert usage.prompt_tokens == 13
     assert usage.completion_tokens == 10
-    assert usage.num_cached_tokens == 4
+    assert usage.total_tokens == 23
+    assert usage.prompt_tokens_details is None
     assert not hasattr(usage, "completion_tokens_details")
 
 


### PR DESCRIPTION
v-a 0.21.0rc1 分支中，包含 MiniMax reasoning usage accounting 补丁，会重建 usage 并补 completion_tokens_details.reasoning_tokens，和当前代码仓中的test_disable_completion_tokens_details.py不兼容，修改代码以适配新的usage