### PR TITLE
feat:支持多模态消息字段校验

### DIFF
--- a/ascend_vllm/middleware/validator_config.json
+++ b/ascend_vllm/middleware/validator_config.json
@@ -9,7 +9,10 @@
                 "subfield": ["messages", "messages.name", "messages.role", "messages.tool_call_id", "messages.tool_calls",
                              "messages.tool_calls.type", "messages.tool_calls.function", "messages.tool_calls.function.arguments", 
                              "messages.tool_calls.function.name", "messages.tool_calls.id", "messages.content", "messages.content.type",
-                             "messages.content.text", "messages.prefix"]
+                             "messages.content.text", "messages.prefix", "messages.content.image_url", "messages.content.image_base64",
+                             "messages.content.video_url", "messages.content.video_base64"],
+                "skip_check_subfield": ["messages.content.image_url", "messages.content.image_base64",
+                                        "messages.content.video_url", "messages.content.video_base64"]
             },
             {
                 "validator_type": "nested_value",
@@ -24,7 +27,7 @@
             {
                 "validator_type": "nested_value",
                 "subfield": ["messages.content.type"],
-                "target_value": ["text"]
+                "target_value": ["text", "image_url", "image_base64", "video_url", "video_base64"]
             }
         ],
         "prompt": {


### PR DESCRIPTION
 ## 变更说明

  本次更新 `ascend_vllm/middleware/validator_config.json`，补充对多模态消息内容字段的校验支持。

  主要变更包括：

  - 在 `messages` 的支持字段列表中新增图片和视频相关字段：
    - `messages.content.image_url`
    - `messages.content.image_base64`
    - `messages.content.video_url`
    - `messages.content.video_base64`
  - 新增 `skip_check_subfield` 配置，跳过上述多模态内容字段的子字段校验。
  - 扩展 `messages.content.type` 的允许值：
    - `text`
    - `image_url`
    - `image_base64`
    - `video_url`
    - `video_base64`

  ## 背景

  当前配置中 `messages.content.type` 仅支持 `text`，无法覆盖图片、视频等多模态输入场景。该变更与最新的 validator 配置保持一致，允许请求中携带多模态消息内容。

  ## 影响范围

  仅更新 validator 配置文件，不涉及业务逻辑代码变更。