### PR TITLE
support vllm 0.23.0

### DIFF
--- a/ascend_vllm/patch/platform/__init__.py
+++ b/ascend_vllm/patch/platform/__init__.py
@@ -1,11 +1,15 @@
 # ruff: noqa: I001
+from vllm_ascend.utils import vllm_version_is
+
 from ascend_vllm.patch.platform import patch_health as patch_health
-from ascend_vllm.patch.platform import (
-    patch_disable_completion_tokens_details as patch_disable_completion_tokens_details,
-)
-from ascend_vllm.patch.platform import (
-    patch_recompute_scheduler as patch_recompute_scheduler,
-)
-from ascend_vllm.patch.platform import (
-    patch_deepseek_v4_validation as patch_deepseek_v4_validation,
-)
+
+if vllm_version_is("0.21.0"):
+    from ascend_vllm.patch.platform import (
+        patch_disable_completion_tokens_details as patch_disable_completion_tokens_details,
+    )
+    from ascend_vllm.patch.platform import (
+        patch_recompute_scheduler as patch_recompute_scheduler,
+    )
+    from ascend_vllm.patch.platform import (
+        patch_deepseek_v4_validation as patch_deepseek_v4_validation,
+    )

--- a/ascend_vllm/patch/worker/__init__.py
+++ b/ascend_vllm/patch/worker/__init__.py
@@ -1,4 +1,7 @@
 # ruff: noqa: I001
-from ascend_vllm.patch.worker import (
-    patch_mooncake_hybrid_connector as patch_mooncake_hybrid_connector,
-)
+from vllm_ascend.utils import vllm_version_is
+
+if vllm_version_is("0.21.0"):
+    from ascend_vllm.patch.worker import (
+        patch_mooncake_hybrid_connector as patch_mooncake_hybrid_connector,
+    )

--- a/ascend_vllm/scripts/patch_third_pkg.sh
+++ b/ascend_vllm/scripts/patch_third_pkg.sh
@@ -8,7 +8,7 @@ export PIP_EXTRA_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple
 pip install --force-reinstall numpy==1.26.4
 
 # Find the installed numpy package path.
-numpy_path="$(pip show numpy | awk '/^Location:/ {print $2; exit}')"
+numpy_path="$(python -c 'import numpy, os; print(os.path.dirname(numpy.__path__[0]))')"
 target_np_path="${numpy_path}/numpy/testing/_private/utils.py"
 
 echo "target numpy path is: ${target_np_path}, fix bug of lscpu running start."

--- a/install_all.sh
+++ b/install_all.sh
@@ -58,7 +58,7 @@ cd ..
 rm -rf jemalloc-5.3.0.tar.bz2
 
 # prepare to install by setuptools.
-pip install setuptools==77.0.3 setuptools_scm  build numpy==1.26.4 msgpack==1.1.2 concurrent-log-handler==0.9.28
+pip install setuptools==77.0.3 setuptools_scm  build numpy==1.26.4 msgpack==1.1.2 concurrent-log-handler==0.9.28 setuptools_rust
 
 # 下载 vllm
 VLLM_DIR="vllm-gpu-${vllm_version}"
@@ -69,7 +69,7 @@ if [ -d "./${VLLM_DIR}" ]; then
   rm -rf "$VLLM_DIR"
 fi
 echo "vllm_version: ${vllm_version}"
-git clone -b v"${vllm_version}" https://github.com/vllm-project/vllm.git --depth 1 "${VLLM_DIR}"
+git clone -b "${vllm_version}" https://github.com/vllm-project/vllm.git --depth 1 "${VLLM_DIR}"
 
 # 下载 vllm-ascend
 VLLM_ASCEND_DIR="vllm-ascend-${vllm_ascend_version}"
@@ -80,7 +80,7 @@ if [ -d "./${VLLM_ASCEND_DIR}" ]; then
   rm -rf "$VLLM_ASCEND_DIR"
 fi
 echo "vllm_ascend_version: ${vllm_ascend_version}"
-git clone -b v"${vllm_ascend_version}" https://github.com/vllm-project/vllm-ascend.git --depth 1 "${VLLM_ASCEND_DIR}"
+git clone -b "${vllm_ascend_version}" https://github.com/vllm-project/vllm-ascend.git --depth 1 "${VLLM_ASCEND_DIR}"
 
 # 安装 vllm patch
 VLLM_PATH=${BUILD_ROOT}/${VLLM_DIR}


### PR DESCRIPTION
Upgrade ascend_vllm to support vLLM 0.23.0 and vllm-ascend releases/v0.23.0.

  Changes:
  - Guard 4 patches (completion_tokens_details, recompute_scheduler,  deepseek_v4_validation, mooncake_hybrid_connector) with vllm_version_is("0.21.0") so they only apply on vLLM 0.21.0 and are skipped on 0.23.0 where they are no longer needed or already upstream.
  - Fix numpy path detection in patch_third_pkg.sh to use Python import instead of pip show, which is more reliable across environments.
  - Fix install_all.sh git clone to pass version strings as-is (without prepending "v"), since vllm-ascend 0.23.0 uses branch name "releases/v0.23.0" rather than "vreleases/v0.23.0".
  - Add setuptools_rust to install dependencies.

  Install:
    sh install_all.sh v0.23.0 releases/v0.23.0