### PR TITLE
add ASCEND_GLOBAL_VISIBLE_DEVICES env to limit the npu_stauts.yaml ch…

### DIFF
--- a/ascend_vllm/patch/platform/patch_health.py
+++ b/ascend_vllm/patch/platform/patch_health.py
@@ -153,6 +153,21 @@ def _get_allow_lists():
     return npu_health_level_allow_list, error_code_allow_list
 
 
+def _get_health_check_devices():
+    health_check_devices_str: str = os.getenv("ASCEND_GLOBAL_VISIBLE_DEVICES", "").lower().strip()
+    if not health_check_devices_str:
+        # 没设置或为空，返回None表示检查所有设备
+        return None
+    # 分割 + trim + 过滤空字符串
+    devices = set()
+    for device in health_check_devices_str.split(","):
+        device = device.strip()
+        if device:
+            devices.add(device)
+
+    return devices if devices else None
+
+
 def _check_npu_resource(npu, npu_health_level_allow_list, error_code_allow_list):
     """检查单个 NPU 资源"""
     if "errLevel" not in npu or "errCodes" not in npu:
@@ -182,19 +197,34 @@ def _check_l1_1520_resource(resource):
     return NPUStatusInfo.HEALTH
 
 
-def _check_all_resources(resources, npu_health_level_allow_list, error_code_allow_list):
+def _check_all_resources(resources, npu_health_level_allow_list, error_code_allow_list, health_check_devices):
     """检查所有资源"""
     for resource in resources:
-        check_res = _single_resource_check(resource, npu_health_level_allow_list, error_code_allow_list)
+        check_res = _single_resource_check(
+            resource, npu_health_level_allow_list, error_code_allow_list, health_check_devices
+        )
         if check_res != NPUStatusInfo.HEALTH:
             return check_res
     return NPUStatusInfo.HEALTH
 
 
-def _single_resource_check(resource, npu_health_level_allow_list, error_code_allow_list):
+def _single_resource_check(resource, npu_health_level_allow_list, error_code_allow_list, health_check_devices):
     if resource["type"].lower() == "npu":
         status = resource.get("status", [])
         for npu in status:
+            name = npu.get("name")
+            name_str = str(name).lower().strip() if name is not None else ""
+            if not name_str:
+                if health_check_devices:
+                    continue
+                res = _check_npu_resource(npu, npu_health_level_allow_list, error_code_allow_list)
+                if res != NPUStatusInfo.HEALTH:
+                    return res
+                continue
+
+            if health_check_devices and name_str not in health_check_devices:
+                continue
+
             res = _check_npu_resource(npu, npu_health_level_allow_list, error_code_allow_list)
             if res != NPUStatusInfo.HEALTH:
                 return res
@@ -218,9 +248,12 @@ def check_npu_status() -> int:
     # 获取白名单
     npu_health_level_allow_list, error_code_allow_list = _get_allow_lists()
 
+    # 获取待健康检查设备
+    health_check_devices = _get_health_check_devices()
+
     # 检查所有资源
     resources = npu_status.get("resources", [])
-    return _check_all_resources(resources, npu_health_level_allow_list, error_code_allow_list)
+    return _check_all_resources(resources, npu_health_level_allow_list, error_code_allow_list, health_check_devices)
 
 
 def apply_health_patches() -> None:


### PR DESCRIPTION
## Description

This PR enhances NPU health checking in containerized vLLM deployments by reading the list of global NPU device IDs from the `ASCEND_GLOBAL_VISIBLE_DEVICES` environment variable. The health endpoint now **only** checks the NPU cards actually allocated to the current container.

### Background

In **non-privileged container deployment** scenarios, containers have a virtualized view of NPU devices. For example:

- If a container is allocated physical cards 8–15, the container **only sees local device IDs 0–7** (not the global IDs).
- This disconnect means the container cannot directly know which global cards it owns.

The `ASCEND_GLOBAL_VISIBLE_DEVICES` environment variable is set by the deployment system (e.g., by the user or orchestrator) to a comma-separated list of **global** card IDs, such as `"8,9,10,11,12,13,14,15"`. This variable provides the authoritative mapping from the container's local view to the actual host NPU devices.

### Current Problem

The `/health` endpoint currently checks **all** NPU cards listed in `npu_status.yaml`. In containerized environments:

- The container may have access to only a subset of host NPUs.
- Errors or faults on **unassigned** cards (not visible to the container) will cause false-positive health failures, leading to unnecessary alerts and potential service disruptions.

### Solution

This PR introduces `_get_health_check_devices()` which parses `ASCEND_GLOBAL_VISIBLE_DEVICES` to build a set of global card IDs to monitor:

- If `ASCEND_GLOBAL_VISIBLE_DEVICES` is **set**, the health check **only** validates NPU cards whose `name` field matches an ID in the set.
- If `ASCEND_GLOBAL_VISIBLE_DEVICES` is **not set**, the health check falls back to the **original behavior** of checking all cards (for backward compatibility with non-containerized or privileged deployments).

#### Key Implementation Details

1. **`_get_health_check_devices()`**: Parses and sanitizes the environment variable, returning `None` when unset (indicating "check all").
2. **`_single_resource_check()`**: Filters NPU status entries by checking whether the card's `name` exists in the allowed device set; cards not in the set are skipped.
3. **Graceful handling**: Cards without a `name` field are only checked when `ASCEND_GLOBAL_VISIBLE_DEVICES` is unset, preserving existing behavior.

### Benefits

- **Accurate health reporting** – Only cards allocated to the container are checked.
- **Reduced false alarms** – Prevents monitoring systems from flagging healthy containers due to external card failures.
- **Better multi-container isolation** – Each container reports health independently for its own NPU resources.
- **Backward compatible** – Existing deployments (without the environment variable) continue to work as before.

### Testing

- [ ] Tested with `ASCEND_GLOBAL_VISIBLE_DEVICES="8,9,10,11,12,13,14,15"` – verified only specified cards are checked.
- [ ] Tested with `ASCEND_GLOBAL_VISIBLE_DEVICES="8,9,10,11,12,13,14,15,1000"` – verified skipping of cards not in the set.
- [ ] Tested with `ASCEND_GLOBAL_VISIBLE_DEVICES` unset – verified full NPU scan (original behavior).
- [ ] Verified that errors on excluded cards are ignored.

### Related Code Changes

- Added `_get_health_check_devices()` helper function.
- Updated `_single_resource_check()` to accept and use the `health_check_devices` filter.
- Modified `check_npu_status()` to pass the filtered device list to the resource checker.