### PR TITLE
fix(api): 无效图片或视频输入时返回 400 错误

### DIFF
--- a/ascend_vllm/patch/platform/__init__.py
+++ b/ascend_vllm/patch/platform/__init__.py
@@ -21,6 +21,8 @@ from ascend_vllm.patch.platform import patch_layernorm as patch_layernorm  # noq
 from ascend_vllm.patch.platform import patch_chunk_fla as patch_chunk_fla  # noqa: F401
 from ascend_vllm.patch.platform import patch_health as patch_health
 from ascend_vllm.patch.platform import patch_detokenizer as patch_detokenizer
+from ascend_vllm.patch.platform import patch_api_server as patch_api_server
+from ascend_vllm.patch.platform import patch_image as patch_image
 from ascend_vllm.patch.platform import (
     patch_disable_completion_tokens_details as patch_disable_completion_tokens_details,
 )

--- a/ascend_vllm/patch/platform/patch_api_server.py
+++ b/ascend_vllm/patch/platform/patch_api_server.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from ascend_vllm.patch.platform.patch_image import InvalidMediaInputError
+from vllm.entrypoints.openai import api_server
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_original_build_app = api_server.build_app
+
+
+async def invalid_media_input_exception_handler(
+    request: Request,
+    exc: InvalidMediaInputError,
+) -> JSONResponse:
+    logger.warning(
+        "Invalid media input: path=%s, detail=%s",
+        request.url.path,
+        exc,
+    )
+    return JSONResponse(
+        status_code=400,
+        content={
+            "error": {
+                "message": str(exc),
+                "type": "invalid_request_error",
+                "param": "messages",
+                "code": "invalid_media_input",
+            }
+        },
+    )
+
+
+def build_app(*args, **kwargs) -> FastAPI:
+    app = _original_build_app(*args, **kwargs)
+    app.add_exception_handler(
+        InvalidMediaInputError,
+        invalid_media_input_exception_handler,
+    )
+    return app
+
+
+api_server.build_app = build_app

--- a/ascend_vllm/patch/platform/patch_api_server.py
+++ b/ascend_vllm/patch/platform/patch_api_server.py
@@ -1,9 +1,9 @@
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
-
-from ascend_vllm.patch.platform.patch_image import InvalidMediaInputError
 from vllm.entrypoints.openai import api_server
 from vllm.logger import init_logger
+
+from ascend_vllm.patch.platform.patch_image import InvalidMediaInputError
 
 logger = init_logger(__name__)
 

--- a/ascend_vllm/patch/platform/patch_image.py
+++ b/ascend_vllm/patch/platform/patch_image.py
@@ -1,0 +1,170 @@
+import aiohttp
+import numpy as np
+import numpy.typing as npt
+import torch
+import asyncio
+
+from pathlib import Path
+from PIL import Image
+from typing import Any
+
+from vllm.multimodal.media.base import MediaIO, MediaWithBytes
+from vllm.multimodal.media.connector import MediaConnector
+from vllm.multimodal.inputs import VideoItem
+from vllm.logger import init_logger
+logger = init_logger(__name__)
+
+
+class InvalidMediaInputError(ValueError):
+    """用户提供的图片/视频路径、URL 或内容不可用。"""
+
+
+def load_file(self, filepath: Path) -> MediaWithBytes[Image.Image]:
+    try:
+        data = filepath.read_bytes()
+    except OSError as e:
+        raise InvalidMediaInputError(
+            f"Cannot read image file '{filepath}': {e}"
+        ) from e
+
+    try:
+        return self.load_bytes(data)
+    except Exception as e:
+        raise InvalidMediaInputError(
+            f"Cannot decode image file '{filepath}': {e}"
+        ) from e
+
+
+_original_fetch_image = MediaConnector.fetch_image
+_original_fetch_image_async = MediaConnector.fetch_image_async
+_original_load_from_url = MediaConnector.load_from_url
+_original_load_from_url_async = MediaConnector.load_from_url_async
+
+
+def _validate_image_url(image_url: Any) -> str:
+    if not isinstance(image_url, str) or not image_url.strip():
+        raise InvalidMediaInputError(
+            "image_url.url must be a non-empty string"
+        )
+    return image_url.strip()
+
+
+def fetch_image(self, image_url, *, image_mode="RGB"):
+    image_url = _validate_image_url(image_url)
+
+    try:
+        return _original_fetch_image(self, image_url, image_mode=image_mode)
+    except aiohttp.ClientResponseError as e:
+        if 400 <= e.status < 500:
+            raise InvalidMediaInputError(
+                f"Cannot fetch image URL '{image_url}': HTTP {e.status}"
+            ) from e
+        raise
+    except aiohttp.ClientError as e:
+        raise InvalidMediaInputError(
+            f"Cannot access image URL '{image_url}': {type(e).__name__}"
+        ) from e
+
+
+async def fetch_image_async(self, image_url, *, image_mode="RGB"):
+    image_url = _validate_image_url(image_url)
+
+    try:
+        return await _original_fetch_image_async(
+            self, image_url, image_mode=image_mode
+        )
+    except aiohttp.ClientResponseError as e:
+        if 400 <= e.status < 500:
+            raise InvalidMediaInputError(
+                f"Cannot fetch image URL '{image_url}': HTTP {e.status}"
+            ) from e
+        raise
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        raise InvalidMediaInputError(
+            f"Cannot access image URL '{image_url}': {type(e).__name__}"
+        ) from e
+
+
+def load_from_url(self, *args, **kwargs):
+    try:
+        return _original_load_from_url(self, *args, **kwargs)
+    except aiohttp.ClientResponseError as e:
+        if 400 <= e.status < 500:
+            raise InvalidMediaInputError(
+                f"Cannot fetch media URL: HTTP {e.status}"
+            ) from e
+        raise
+    except aiohttp.ClientError as e:
+        raise InvalidMediaInputError(
+            f"Cannot access media URL: {type(e).__name__}"
+        ) from e
+
+
+async def load_from_url_async(self, *args, **kwargs):
+    try:
+        return await _original_load_from_url_async(self, *args, **kwargs)
+    except aiohttp.ClientResponseError as e:
+        if 400 <= e.status < 500:
+            raise InvalidMediaInputError(
+                f"Cannot fetch media URL: HTTP {e.status}"
+            ) from e
+        raise
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        raise InvalidMediaInputError(
+            f"Cannot access media URL: {type(e).__name__}"
+        ) from e
+
+
+def load_file_video(self, filepath: Path) -> tuple[npt.NDArray, dict[str, Any]]:
+    try:
+        with filepath.open("rb") as f:
+            data = f.read()
+    except OSError as e:
+        raise InvalidMediaInputError(
+            f"Cannot read video file '{filepath}': {e}"
+        ) from e
+
+    try:
+        return self.load_bytes(data)
+    except Exception as e:
+        raise InvalidMediaInputError(
+            f"Cannot decode video file '{filepath}': {e}"
+        ) from e
+
+
+def _get_video_with_metadata(
+    self,
+    video: VideoItem,
+) -> tuple[np.ndarray, dict[str, Any] | None]:
+    if isinstance(video, tuple):
+        return video
+
+    try:
+        if isinstance(video, list):
+            return np.array(video), None
+        if isinstance(video, np.ndarray):
+            return video, None
+        if isinstance(video, torch.Tensor):
+            return video.numpy(), None
+    except Exception as e:
+        raise InvalidMediaInputError(
+            f"Cannot convert video input of type "
+            f"'{type(video).__name__}': {e}"
+        ) from e
+
+    raise InvalidMediaInputError(
+        f"Parameter 'video' has unsupported type: "
+        f"'{type(video).__name__}'"
+    )
+
+
+from vllm.multimodal.media.image import ImageMediaIO
+from vllm.multimodal.media.video import VideoMediaIO
+from vllm.multimodal.parse import MultiModalDataParser
+ImageMediaIO.load_file = load_file
+VideoMediaIO.load_file = load_file_video
+MultiModalDataParser._get_video_with_metadata = _get_video_with_metadata
+MediaConnector.fetch_image = fetch_image
+MediaConnector.fetch_image_async = fetch_image_async
+MediaConnector.load_from_url = load_from_url
+MediaConnector.load_from_url_async = load_from_url_async

--- a/ascend_vllm/patch/platform/patch_image.py
+++ b/ascend_vllm/patch/platform/patch_image.py
@@ -1,17 +1,19 @@
+from pathlib import Path
+from typing import Any
+
 import aiohttp
 import numpy as np
 import numpy.typing as npt
 import torch
-import asyncio
-
-from pathlib import Path
 from PIL import Image
-from typing import Any
-
-from vllm.multimodal.media.base import MediaIO, MediaWithBytes
-from vllm.multimodal.media.connector import MediaConnector
-from vllm.multimodal.inputs import VideoItem
 from vllm.logger import init_logger
+from vllm.multimodal.inputs import VideoItem
+from vllm.multimodal.media.base import MediaWithBytes
+from vllm.multimodal.media.connector import MediaConnector
+from vllm.multimodal.media.image import ImageMediaIO
+from vllm.multimodal.media.video import VideoMediaIO
+from vllm.multimodal.parse import MultiModalDataParser
+
 logger = init_logger(__name__)
 
 
@@ -23,16 +25,12 @@ def load_file(self, filepath: Path) -> MediaWithBytes[Image.Image]:
     try:
         data = filepath.read_bytes()
     except OSError as e:
-        raise InvalidMediaInputError(
-            f"Cannot read image file '{filepath}': {e}"
-        ) from e
+        raise InvalidMediaInputError(f"Cannot read image file '{filepath}': {e}") from e
 
     try:
         return self.load_bytes(data)
     except Exception as e:
-        raise InvalidMediaInputError(
-            f"Cannot decode image file '{filepath}': {e}"
-        ) from e
+        raise InvalidMediaInputError(f"Cannot decode image file '{filepath}': {e}") from e
 
 
 _original_fetch_image = MediaConnector.fetch_image
@@ -43,9 +41,7 @@ _original_load_from_url_async = MediaConnector.load_from_url_async
 
 def _validate_image_url(image_url: Any) -> str:
     if not isinstance(image_url, str) or not image_url.strip():
-        raise InvalidMediaInputError(
-            "image_url.url must be a non-empty string"
-        )
+        raise InvalidMediaInputError("image_url.url must be a non-empty string")
     return image_url.strip()
 
 
@@ -56,63 +52,49 @@ def fetch_image(self, image_url, *, image_mode="RGB"):
         return _original_fetch_image(self, image_url, image_mode=image_mode)
     except aiohttp.ClientResponseError as e:
         if 400 <= e.status < 500:
-            raise InvalidMediaInputError(
-                f"Cannot fetch image URL '{image_url}': HTTP {e.status}"
-            ) from e
+            raise InvalidMediaInputError(f"Cannot fetch image URL '{image_url}': HTTP {e.status}") from e
         raise
     except aiohttp.ClientError as e:
-        raise InvalidMediaInputError(
-            f"Cannot access image URL '{image_url}': {type(e).__name__}"
-        ) from e
+        raise InvalidMediaInputError(f"Cannot access image URL '{image_url}': {type(e).__name__}") from e
 
 
 async def fetch_image_async(self, image_url, *, image_mode="RGB"):
     image_url = _validate_image_url(image_url)
 
     try:
-        return await _original_fetch_image_async(
-            self, image_url, image_mode=image_mode
-        )
+        return await _original_fetch_image_async(self, image_url, image_mode=image_mode)
     except aiohttp.ClientResponseError as e:
         if 400 <= e.status < 500:
-            raise InvalidMediaInputError(
-                f"Cannot fetch image URL '{image_url}': HTTP {e.status}"
-            ) from e
+            raise InvalidMediaInputError(f"Cannot fetch image URL '{image_url}': HTTP {e.status}") from e
         raise
-    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-        raise InvalidMediaInputError(
-            f"Cannot access image URL '{image_url}': {type(e).__name__}"
-        ) from e
+    except (TimeoutError, aiohttp.ClientError) as e:
+        raise InvalidMediaInputError(f"Cannot access image URL '{image_url}': {type(e).__name__}") from e
 
 
 def load_from_url(self, *args, **kwargs):
+    url = kwargs.get("url", args[0] if args else "<unknown>")
+
     try:
         return _original_load_from_url(self, *args, **kwargs)
     except aiohttp.ClientResponseError as e:
         if 400 <= e.status < 500:
-            raise InvalidMediaInputError(
-                f"Cannot fetch media URL: HTTP {e.status}"
-            ) from e
+            raise InvalidMediaInputError(f"Cannot fetch media URL '{url}': HTTP {e.status}") from e
         raise
     except aiohttp.ClientError as e:
-        raise InvalidMediaInputError(
-            f"Cannot access media URL: {type(e).__name__}"
-        ) from e
+        raise InvalidMediaInputError(f"Cannot access media URL '{url}': {type(e).__name__}") from e
 
 
 async def load_from_url_async(self, *args, **kwargs):
+    url = kwargs.get("url", args[0] if args else "<unknown>")
+
     try:
         return await _original_load_from_url_async(self, *args, **kwargs)
     except aiohttp.ClientResponseError as e:
         if 400 <= e.status < 500:
-            raise InvalidMediaInputError(
-                f"Cannot fetch media URL: HTTP {e.status}"
-            ) from e
+            raise InvalidMediaInputError(f"Cannot fetch media URL '{url}': HTTP {e.status}") from e
         raise
-    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-        raise InvalidMediaInputError(
-            f"Cannot access media URL: {type(e).__name__}"
-        ) from e
+    except (TimeoutError, aiohttp.ClientError) as e:
+        raise InvalidMediaInputError(f"Cannot access media URL '{url}': {type(e).__name__}") from e
 
 
 def load_file_video(self, filepath: Path) -> tuple[npt.NDArray, dict[str, Any]]:
@@ -120,16 +102,12 @@ def load_file_video(self, filepath: Path) -> tuple[npt.NDArray, dict[str, Any]]:
         with filepath.open("rb") as f:
             data = f.read()
     except OSError as e:
-        raise InvalidMediaInputError(
-            f"Cannot read video file '{filepath}': {e}"
-        ) from e
+        raise InvalidMediaInputError(f"Cannot read video file '{filepath}': {e}") from e
 
     try:
         return self.load_bytes(data)
     except Exception as e:
-        raise InvalidMediaInputError(
-            f"Cannot decode video file '{filepath}': {e}"
-        ) from e
+        raise InvalidMediaInputError(f"Cannot decode video file '{filepath}': {e}") from e
 
 
 def _get_video_with_metadata(
@@ -147,20 +125,11 @@ def _get_video_with_metadata(
         if isinstance(video, torch.Tensor):
             return video.numpy(), None
     except Exception as e:
-        raise InvalidMediaInputError(
-            f"Cannot convert video input of type "
-            f"'{type(video).__name__}': {e}"
-        ) from e
+        raise InvalidMediaInputError(f"Cannot convert video input of type '{type(video).__name__}': {e}") from e
 
-    raise InvalidMediaInputError(
-        f"Parameter 'video' has unsupported type: "
-        f"'{type(video).__name__}'"
-    )
+    raise InvalidMediaInputError(f"Parameter 'video' has unsupported type: '{type(video).__name__}'")
 
 
-from vllm.multimodal.media.image import ImageMediaIO
-from vllm.multimodal.media.video import VideoMediaIO
-from vllm.multimodal.parse import MultiModalDataParser
 ImageMediaIO.load_file = load_file
 VideoMediaIO.load_file = load_file_video
 MultiModalDataParser._get_video_with_metadata = _get_video_with_metadata


### PR DESCRIPTION
- 校验图片 URL 是否为空或类型非法
- 捕获媒体文件读取、解码、请求及转换异常
- 处理不支持的视频输入类型
- 注册 FastAPI 媒体输入异常处理器
- 返回兼容 OpenAI 格式的 invalid_request_error