### PR TITLE
Add uvicorn.access logger to logging config

### DIFF
--- a/tools/logging/update_logging_config.py
+++ b/tools/logging/update_logging_config.py
@@ -117,6 +117,11 @@ def _build_logging_config(log_file_name: str) -> dict[str, Any]:
                 "level": VLLM_LOGGING_LEVEL,
                 "propagate": False,
             },
+            "uvicorn.access": {
+                "handlers": ["vllm", "console"],
+                "level": VLLM_LOGGING_LEVEL,
+                "propagate": False,
+            },
         },
         "version": 1,
         "disable_existing_loggers": False,


### PR DESCRIPTION
## Summary
- Add uvicorn.access logger to logging config so that HTTP request/response logs from curl are recorded to both log file and console
- Previously, uvicorn access logs were not captured because no logger was configured for the uvicorn.access namespace