### PR TITLE
Fix service crash due to out-of-bounds draft tokens

### DIFF
--- a/ascend_vllm/patch/worker/__init__.py
+++ b/ascend_vllm/patch/worker/__init__.py
@@ -8,6 +8,15 @@ from vllm_ascend.utils import (
 from ascend_vllm.patch.worker import (
     patch_mooncake_hybrid_connector as patch_mooncake_hybrid_connector,
 )
+from ascend_vllm.patch.worker import (
+    patch_dspark_proposer as patch_dspark_proposer,
+)
+from ascend_vllm.patch.worker import (
+    patch_spec_decode_draft as patch_spec_decode_draft,
+)
+from ascend_vllm.patch.worker import (
+    patch_spec_decode_utils as patch_spec_decode_utils,
+)
 
 if get_ascend_device_type() == AscendDeviceType.A5 and vllm_version_is("0.25.1"):
     from ascend_vllm.patch.worker import patch_deepseek_v4_dspark as patch_deepseek_v4_dspark

--- a/ascend_vllm/patch/worker/patch_dspark_proposer.py
+++ b/ascend_vllm/patch/worker/patch_dspark_proposer.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from vllm.v1.attention.backends.utils import CommonAttentionMetadata
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
+
+from ascend_vllm.patch.worker.patch_spec_decode_utils import (
+    copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid,
+)
+
+_PATCH_APPLIED = False
+
+
+def _dspark_set_inputs_first_pass(
+    self,
+    target_token_ids: torch.Tensor,
+    next_token_ids: torch.Tensor,
+    target_positions: torch.Tensor,
+    target_hidden_states: torch.Tensor,
+    token_indices_to_sample: torch.Tensor | None,
+    cad: CommonAttentionMetadata,
+    num_rejected_tokens_gpu: torch.Tensor | None,
+    req_scheduled_tokens=None,
+    long_seq_metadata=None,
+    num_prefill_reqs=0,
+    num_decode_reqs=0,
+) -> tuple[int, torch.Tensor, CommonAttentionMetadata, tuple[Any, Any] | None]:
+    # The initial input token of markovHead is the next token
+    n = next_token_ids.shape[0]
+    self._dspark_seed_buffer[:n].copy_(next_token_ids)
+    self._dspark_seed_buffer[n:].fill_(0)
+    batch_size = cad.num_reqs
+    num_query_total = batch_size * self.num_query_per_req
+    num_sample_total = batch_size * self.num_speculative_tokens
+    has_num_rejected = num_rejected_tokens_gpu is not None
+    primary_gid = getattr(self, "kv_cache_gid", 0)
+    self._per_group_block_table_buffers = {
+        attn_group.kv_cache_group_id: self._per_group_block_tables[attn_group.kv_cache_group_id]
+        for attn_group in self.draft_attn_groups
+    }
+    self._context_slot_mapping_buffers = None
+    self._dflash_num_context = int(cad.query_start_loc_cpu[batch_size])
+    self._dflash_hidden_states[: self._dflash_num_context] = target_hidden_states[: self._dflash_num_context]
+
+    token_indices_to_sample = torch.empty(
+        num_sample_total,
+        dtype=torch.int32,
+        device=self.device,
+    )
+
+    # Query block: reuse the DFlash inputs kernel logic (host-side ref)
+    # per kv-cache-group to fill positions / input_ids / query slot_mapping
+    # / token_indices.
+    draft_attn_groups = getattr(self, "draft_attn_groups", [])
+    for attn_group in draft_attn_groups:
+        gid = attn_group.kv_cache_group_id
+        gid_block_table = self._per_group_block_table_buffers.get(gid)
+        if gid_block_table is None:
+            continue
+        kv_block_size = int(attn_group.kv_cache_spec.block_size)
+        if batch_size > 0:
+            copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[batch_size,](
+                # Inputs
+                next_token_ids_ptr=next_token_ids,
+                target_positions_ptr=target_positions,
+                context_slot_mapping_ptr=self._per_group_slot_mappings[gid],
+                # Outputs
+                out_input_ids_ptr=self.input_ids,
+                out_context_positions_ptr=self._context_positions_buffer,
+                out_query_positions_ptr=self.positions,
+                out_context_slot_mapping_ptr=self._per_group_context_slot_mapping_buffers[gid],
+                out_query_slot_mapping_ptr=self._per_group_query_slot_mapping_buffers[gid],
+                out_token_indices_ptr=token_indices_to_sample,
+                # Block table
+                block_table_ptr=gid_block_table,
+                block_table_stride=gid_block_table.stride(0),
+                # Metadata
+                query_start_loc_ptr=cad.query_start_loc,
+                seq_lens_ptr=cad.seq_lens,
+                num_rejected_tokens_ptr=num_rejected_tokens_gpu,
+                # Scalars
+                parallel_drafting_token_id=self.parallel_drafting_token_id,
+                block_size=kv_block_size,
+                num_query_per_req=self.num_query_per_req,
+                num_speculative_tokens=self.num_speculative_tokens,
+                total_input_tokens=self._dflash_num_context,
+                batch_size=batch_size,
+                max_model_len=self.max_model_len,
+                HAS_NUM_REJECTED=has_num_rejected,
+                SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
+            )
+    # to compute self._context_slot_mapping_buffers from dict to list
+    self._context_slot_mapping_buffers = [
+        self._per_group_context_slot_mapping_buffers[gidx] for gidx in self._layer_group_idx
+    ]
+
+    effective_seq_lens = cad.seq_lens
+    if has_num_rejected:
+        effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu
+
+    cad.query_start_loc = self.arange_dflash[: batch_size + 1] * self.num_query_per_req
+    cad.seq_lens = effective_seq_lens + self.num_query_per_req
+    cad.query_start_loc_cpu = (
+        torch.from_numpy(self.token_arange_np[: batch_size + 1]).clone() * self.num_query_per_req
+    ).to(torch.int32)
+
+    if hasattr(cad, "actual_seq_lengths_q"):
+        cad.actual_seq_lengths_q = [self.num_query_per_req] * batch_size
+    if hasattr(cad, "decode_token_per_req"):
+        cad.decode_token_per_req = self.num_query_per_req
+
+    cad.num_actual_tokens = num_query_total
+    cad.num_input_tokens = num_query_total
+    cad.max_query_len = self.num_query_per_req
+    cad.max_seq_len = cad.max_seq_len + self.num_query_per_req
+    cad.slot_mapping = self._per_group_query_slot_mapping_buffers[primary_gid][:num_query_total]
+    cad.positions = self.positions  # this would be sliced in attention backend
+    cad.causal = False
+    cad.attn_mask = None
+    cad.attn_state = AscendAttentionState.ChunkedPrefill
+
+    return num_query_total, token_indices_to_sample, cad, None
+
+
+def apply_patch() -> None:
+    global _PATCH_APPLIED
+    if _PATCH_APPLIED:
+        return
+
+    import vllm_ascend.spec_decode.dspark_proposer as dspark_mod
+    from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
+
+    dspark_mod.copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid = (
+        copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
+    )
+
+    AscendDSparkProposer.set_inputs_first_pass = _dspark_set_inputs_first_pass
+
+    _PATCH_APPLIED = True
+
+
+apply_patch()

--- a/ascend_vllm/patch/worker/patch_spec_decode_drafter.py
+++ b/ascend_vllm/patch/worker/patch_spec_decode_drafter.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import functools
+
+import torch
+from vllm.logger import init_logger
+
+logger = init_logger("vllm.ascend_vllm.patch.worker.patch_spec_decode_drafter")
+
+_PATCH_APPLIED = False
+
+
+def _patch_propose_draft_token_ids() -> None:
+    from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+    original = NPUModelRunner.propose_draft_token_ids
+
+    if getattr(original, "_modelarts_drafter_skip_patch_applied", False):
+        return
+
+    @functools.wraps(original)
+    def patched_propose_draft_token_ids(
+        self,
+        valid_sampled_token_ids,
+        sampling_metadata,
+        scheduler_output,
+        spec_decode_metadata,
+        spec_decode_common_attn_metadata,
+        positions,
+        num_scheduled_tokens,
+        hidden_states,
+        aux_hidden_states=None,
+        sample_hidden_states=None,
+        target_model_batch_desc=None,
+    ):
+        # Second-layer protection: skip drafter when the sequence is too
+        # close to max_model_len, preventing out-of-bounds positions in
+        # the Triton kernel and avoiding wasted draft computation.
+        if self.speculative_config and spec_decode_common_attn_metadata is not None:
+            input_fits = self._input_fits_in_drafter(spec_decode_common_attn_metadata)
+            if not input_fits:
+                # DP sync: when dp_size > 1, all DP ranks must call the
+                # drafter to keep collective communication consistent.
+                # Use dummy_run as a no-op substitute.
+                if self.dp_size > 1:
+                    self.drafter.dummy_run(num_tokens=1)
+
+                # Return zero draft tokens so the nested caller in
+                # sample_tokens assigns zeros to self._draft_token_ids
+                # and _copy_draft_token_ids_to_cpu propagates them.
+                # This prevents stale drafts from the previous step.
+                num_reqs = len(self.input_batch.req_ids)
+                draft_token_ids = torch.zeros(1, device=self.device, dtype=torch.int32).expand(
+                    num_reqs, self.num_spec_tokens
+                )
+                return draft_token_ids
+
+        # Normal path: delegate to the original method.
+        return original(
+            self,
+            valid_sampled_token_ids,
+            sampling_metadata,
+            scheduler_output,
+            spec_decode_metadata,
+            spec_decode_common_attn_metadata,
+            positions,
+            num_scheduled_tokens,
+            hidden_states,
+            aux_hidden_states,
+            sample_hidden_states,
+            target_model_batch_desc,
+        )
+
+    patched_propose_draft_token_ids._modelarts_drafter_skip_patch_applied = True
+    NPUModelRunner.propose_draft_token_ids = patched_propose_draft_token_ids
+
+
+def apply_patch() -> None:
+    global _PATCH_APPLIED
+    if _PATCH_APPLIED:
+        return
+
+    _patch_propose_draft_token_ids()
+
+    _PATCH_APPLIED = True
+
+
+apply_patch()

--- a/ascend_vllm/patch/worker/patch_spec_decode_utils.py
+++ b/ascend_vllm/patch/worker/patch_spec_decode_utils.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from vllm.triton_utils import tl, triton
+
+_PATCH_APPLIED = False
+
+
+@triton.jit
+def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
+    # Inputs
+    next_token_ids_ptr,  # [num_reqs]
+    target_positions_ptr,  # [num_context]
+    context_slot_mapping_ptr,  # [num_context]
+    # Outputs
+    out_input_ids_ptr,  # [num_query_total] (output)
+    out_context_positions_ptr,  # [num_context] (output)
+    out_query_positions_ptr,  # [num_query_total] (output)
+    out_context_slot_mapping_ptr,  # [num_context] (output)
+    out_query_slot_mapping_ptr,  # [num_query_total] (output)
+    out_token_indices_ptr,  # [num_reqs * num_speculative_tokens] (output)
+    # Block table
+    block_table_ptr,  # [max_reqs, max_blocks]
+    block_table_stride,  # stride of block_table dim 0 (in elements)
+    # Metadata
+    query_start_loc_ptr,  # [num_reqs + 1]
+    seq_lens_ptr,  # [num_reqs]
+    num_rejected_tokens_ptr,  # [num_reqs] or null (0) when not padded
+    # Scalars
+    parallel_drafting_token_id,  # tl.int32
+    block_size,  # tl.int32
+    num_query_per_req,  # tl.int32
+    num_speculative_tokens,  # tl.int32
+    total_input_tokens,  # tl.int32
+    batch_size,  # tl.int32
+    max_model_len,  # tl.int32
+    HAS_NUM_REJECTED: tl.constexpr = False,
+    SAMPLE_FROM_ANCHOR: tl.constexpr = False,
+):
+    req_idx = tl.program_id(axis=0)
+    ctx_start = tl.load(query_start_loc_ptr + req_idx)
+    ctx_end = tl.load(query_start_loc_ptr + req_idx + 1)
+    num_ctx = ctx_end - ctx_start
+
+    for j in range(0, num_ctx):
+        ctx_pos_idx = ctx_start + j
+        pos = tl.load(target_positions_ptr + ctx_pos_idx)
+        tl.store(out_context_positions_ptr + ctx_pos_idx, pos)
+
+        slot = tl.load(context_slot_mapping_ptr + ctx_pos_idx)
+        tl.store(out_context_slot_mapping_ptr + ctx_pos_idx, slot)
+
+    if HAS_NUM_REJECTED:
+        num_rejected = tl.load(num_rejected_tokens_ptr + req_idx)
+        valid_ctx_end = ctx_end - num_rejected
+    else:
+        num_rejected = 0
+        valid_ctx_end = ctx_end
+
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    effective_seq_len = seq_len - num_rejected
+    last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
+
+    for q_idx in range(0, num_query_per_req):
+        query_pos = last_pos + 1 + q_idx
+        query_out_idx = req_idx * num_query_per_req + q_idx
+
+        # Clamp query_pos to max_model_len - 1 to avoid out-of-bounds access in
+        # position embeddings when draft tokens exceed the model's maximum sequence length.
+        # Draft tokens with clamped positions should be ignored in the attention backend.
+        is_valid = query_pos < max_model_len
+        safe_query_pos = tl.minimum(query_pos, max_model_len - 1)
+        tl.store(out_query_positions_ptr + query_out_idx, safe_query_pos)
+
+        query_cache_pos = effective_seq_len + q_idx
+        block_num_q = query_cache_pos // block_size
+        # Mask out-of-bounds block_num_q to avoid out-of-bounds access in block_table
+        block_id_q = tl.load(
+            block_table_ptr + req_idx * block_table_stride + block_num_q,
+            mask=is_valid,
+            other=0,
+        ).to(tl.int64)
+        slot_q = block_id_q * block_size + (query_cache_pos % block_size)
+        tl.store(out_query_slot_mapping_ptr + query_out_idx, slot_q)
+
+        if q_idx == 0:
+            bonus_token = tl.load(next_token_ids_ptr + req_idx)
+            tl.store(out_input_ids_ptr + query_out_idx, bonus_token)
+        else:
+            tl.store(out_input_ids_ptr + query_out_idx, parallel_drafting_token_id)
+
+        if SAMPLE_FROM_ANCHOR:
+            sample_out_idx = req_idx * num_speculative_tokens + q_idx
+            tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)
+        else:
+            if q_idx > 0:
+                sample_out_idx = req_idx * num_speculative_tokens + (q_idx - 1)
+                tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)
+
+
+def apply_patch() -> None:
+    global _PATCH_APPLIED
+    if _PATCH_APPLIED:
+        return
+
+    from vllm_ascend.ops.triton.spec_decode import utils as spec_decode_utils
+
+    spec_decode_utils.copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid = (
+        copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
+    )
+
+    _PATCH_APPLIED = True
+
+
+apply_patch()


### PR DESCRIPTION
At this boundary, draft tokens could generate query positions beyond the model's maximum sequence length, causing an out-of-bounds access and triggering a failure in the CANN IndexCheck operator.
The fix adds multiple layers of protection:
Stops the request middleware from injecting a fixed default max_tokens, allowing the serving stack to apply model-aware defaults and validation.
Skips draft-token generation when the input no longer fits within max_model_len.
Returns zero draft tokens on the skipped path to prevent stale draft tokens from a previous decoding step.
Preserves data-parallel synchronization by performing a dummy drafter run when required.
Updates  DSpark input preparation to correctly handle rejected tokens, query metadata, positions, and slot mappings.
Clamps speculative query positions to max_model_len - 1.
Masks invalid block-table accesses for draft tokens that exceed the model boundary.
The normal speculative decoding path remains unchanged when sufficient sequence capacity is available.