### PR TITLE
test: add unit tests for A5-specific patches (PR #1893)

### DIFF
--- a/tests/patch/platform/test_patch_vllm_ascend_utils.py
+++ b/tests/patch/platform/test_patch_vllm_ascend_utils.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import types
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+PATCH_PATH = ROOT / "ascend_vllm" / "patch" / "platform" / "patch_vllm_ascend_utils.py"
+
+
+def _make_package(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module.__path__ = []  # type: ignore[attr-defined]
+    return module
+
+
+def _install_dependency_stubs(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Install stub modules for vllm_ascend.utils, vllm.platforms.interface, and vllm_ascend.cpu_binding."""
+    vllm = _make_package("vllm")
+    vllm_platforms = _make_package("vllm.platforms")
+    interface_mod = types.ModuleType("vllm.platforms.interface")
+
+    original_get_assigned_physical_gpu_ids = object()
+    interface_mod.get_assigned_physical_gpu_ids = original_get_assigned_physical_gpu_ids  # type: ignore[attr-defined]
+    vars(vllm_platforms)["interface"] = interface_mod
+
+    vllm_ascend = _make_package("vllm_ascend")
+    vllm_ascend_utils = types.ModuleType("vllm_ascend.utils")
+    original_setup = object()
+    vllm_ascend_utils.setup_ascend_local_comm_res = original_setup  # type: ignore[attr-defined]
+    vllm_ascend_cpu_binding = types.ModuleType("vllm_ascend.cpu_binding")
+
+    class _DeviceInfo:
+        @staticmethod
+        def get_npu_map_info() -> list[str]:
+            return []
+
+    vllm_ascend_cpu_binding.DeviceInfo = _DeviceInfo  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "vllm", vllm)
+    monkeypatch.setitem(sys.modules, "vllm.platforms", vllm_platforms)
+    monkeypatch.setitem(sys.modules, "vllm.platforms.interface", interface_mod)
+    monkeypatch.setitem(sys.modules, "vllm_ascend", vllm_ascend)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.utils", vllm_ascend_utils)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.cpu_binding", vllm_ascend_cpu_binding)
+
+    return {
+        "interface": interface_mod,
+        "original_get_assigned_physical_gpu_ids": original_get_assigned_physical_gpu_ids,
+        "vllm_ascend_utils": vllm_ascend_utils,
+        "original_setup": original_setup,
+        "_DeviceInfo": _DeviceInfo,
+    }
+
+
+def _load_patch_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Any, dict[str, Any]]:
+    stubs = _install_dependency_stubs(monkeypatch)
+
+    module_name = f"patch_vllm_ascend_utils_under_test_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, PATCH_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+
+    return module, stubs
+
+
+class _FakeKVTransferConfig:
+    """Mimics the subset of the kv_transfer_config object used by the patch."""
+
+    def __init__(self, extra_config: dict[str, Any] | None) -> None:
+        self.kv_connector_extra_config = extra_config
+
+
+def _write_endpoint_config(directory: Path, device_id: int, payload: dict[str, Any]) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / f"ub_endpoint_npu_{device_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _set_assigned_ids(monkeypatch: pytest.MonkeyPatch, module: Any, ids: list[int] | None) -> MagicMock:
+    """Replace the local get_assigned_physical_gpu_ids binding in the patch module."""
+    mock = MagicMock(return_value=ids)
+    monkeypatch.setattr(module, "get_assigned_physical_gpu_ids", mock)
+    return mock
+
+
+class TestPatchVllmAscendUtils:
+    """Tests for the setup_ascend_local_comm_res override in patch_vllm_ascend_utils.py."""
+
+    def test_patch_replaces_setup_ascend_local_comm_res(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Importing the patch module replaces setup_ascend_local_comm_res on vllm_ascend.utils."""
+        module, stubs = _load_patch_module(monkeypatch)
+        vllm_ascend_utils = stubs["vllm_ascend_utils"]
+
+        assert vllm_ascend_utils.setup_ascend_local_comm_res is module.setup_ascend_local_comm_res
+        assert vllm_ascend_utils.setup_ascend_local_comm_res is not stubs["original_setup"]
+
+    def test_returns_early_when_kv_transfer_config_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When kv_transfer_config is None, no device lookup and no env mutation occur."""
+        module, _ = _load_patch_module(monkeypatch)
+        monkeypatch.delenv("ASCEND_LOCAL_COMM_RES", raising=False)
+
+        module.setup_ascend_local_comm_res(0, None)
+
+        assert "ASCEND_LOCAL_COMM_RES" not in os.environ
+
+    def test_returns_early_when_local_comm_res_path_is_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When ascend_local_comm_res_path is absent, the function exits without touching the env."""
+        module, _ = _load_patch_module(monkeypatch)
+        monkeypatch.delenv("ASCEND_LOCAL_COMM_RES", raising=False)
+        _set_assigned_ids(monkeypatch, module, [0])
+        config = _FakeKVTransferConfig(extra_config={})
+
+        module.setup_ascend_local_comm_res(0, config)
+
+        assert "ASCEND_LOCAL_COMM_RES" not in os.environ
+
+    def test_loads_endpoint_config_and_sets_env_var_with_assigned_devices(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Happy path: reads endpoint JSON from the directory and sets ASCEND_LOCAL_COMM_RES compactly."""
+        module, _ = _load_patch_module(monkeypatch)
+        monkeypatch.delenv("ASCEND_LOCAL_COMM_RES", raising=False)
+
+        endpoint_dir = tmp_path / "endpoints"
+        payload = {
+            "device_id": 2,
+            "host_ip": "10.0.0.2",
+            "rank_table": {"version": "1.0", "items": []},
+        }
+        _write_endpoint_config(endpoint_dir, device_id=2, payload=payload)
+        _set_assigned_ids(monkeypatch, module, [2])
+        config = _FakeKVTransferConfig(extra_config={"ascend_local_comm_res_path": str(endpoint_dir)})
+
+        module.setup_ascend_local_comm_res(0, config)
+
+        encoded = os.environ["ASCEND_LOCAL_COMM_RES"]
+        assert json.loads(encoded) == payload
+        assert ", " not in encoded
+        assert ": " not in encoded
+
+    def test_falls_back_to_ascend_rt_visible_devices_when_assigned_ids_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When get_assigned_physical_gpu_ids returns None, ASCEND_RT_VISIBLE_DEVICES is used."""
+        module, _ = _load_patch_module(monkeypatch)
+        monkeypatch.delenv("ASCEND_LOCAL_COMM_RES", raising=False)
+        monkeypatch.setenv("ASCEND_RT_VISIBLE_DEVICES", "1,2,3")
+
+        _set_assigned_ids(monkeypatch, module, None)
+        endpoint_dir = tmp_path / "endpoints"
+        payload = {"device_id": 1, "host_ip": "10.0.0.1"}
+        _write_endpoint_config(endpoint_dir, device_id=1, payload=payload)
+
+        config = _FakeKVTransferConfig(extra_config={"ascend_local_comm_res_path": str(endpoint_dir)})
+
+        module.setup_ascend_local_comm_res(0, config)
+
+        assert json.loads(os.environ["ASCEND_LOCAL_COMM_RES"]) == payload
+
+    def test_falls_back_to_device_info_when_env_and_assigned_ids_absent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When neither assigned IDs nor ASCEND_RT_VISIBLE_DEVICES exist, DeviceInfo.get_npu_map_info is used."""
+        module, stubs = _load_patch_module(monkeypatch)
+        monkeypatch.delenv("ASCEND_LOCAL_COMM_RES", raising=False)
+        monkeypatch.delenv("ASCEND_RT_VISIBLE_DEVICES", raising=False)
+
+        _set_assigned_ids(monkeypatch, module, None)
+        device_info_cls = stubs["_DeviceInfo"]
+        device_info_cls.get_npu_map_info = MagicMock(return_value=["7", "5", "9"])  # type: ignore[assignment]
+
+        endpoint_dir = tmp_path / "endpoints"
+        payload = {"device_id": 5, "host_ip": "10.0.0.5"}
+        _write_endpoint_config(endpoint_dir, device_id=5, payload=payload)
+
+        config = _FakeKVTransferConfig(extra_config={"ascend_local_comm_res_path": str(endpoint_dir)})
+
+        module.setup_ascend_local_comm_res(0, config)
+
+        device_info_cls.get_npu_map_info.assert_called_once_with()
+        assert json.loads(os.environ["ASCEND_LOCAL_COMM_RES"]) == payload
+
+    def test_raises_value_error_when_local_rank_is_out_of_bounds(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A local_rank outside the device list raises ValueError."""
+        module, _ = _load_patch_module(monkeypatch)
+        monkeypatch.delenv("ASCEND_LOCAL_COMM_RES", raising=False)
+
+        endpoint_dir = tmp_path / "endpoints"
+        _write_endpoint_config(endpoint_dir, device_id=0, payload={"device_id": 0})
+
+        _set_assigned_ids(monkeypatch, module, [0, 1])
+        config = _FakeKVTransferConfig(extra_config={"ascend_local_comm_res_path": str(endpoint_dir)})
+
+        with pytest.raises(ValueError, match="local_rank 5 is out of bounds"):
+            module.setup_ascend_local_comm_res(5, config)
+
+        assert "ASCEND_LOCAL_COMM_RES" not in os.environ
+
+    def test_raises_filenotfounderror_when_endpoint_file_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """If the per-device endpoint JSON file does not exist, FileNotFoundError is raised with a helpful message."""
+        module, _ = _load_patch_module(monkeypatch)
+        monkeypatch.delenv("ASCEND_LOCAL_COMM_RES", raising=False)
+
+        endpoint_dir = tmp_path / "missing"
+        endpoint_dir.mkdir(parents=True, exist_ok=True)
+        _set_assigned_ids(monkeypatch, module, [4])
+        config = _FakeKVTransferConfig(extra_config={"ascend_local_comm_res_path": str(endpoint_dir)})
+
+        with pytest.raises(FileNotFoundError, match="Endpoint config file not found"):
+            module.setup_ascend_local_comm_res(0, config)
+
+        assert "ASCEND_LOCAL_COMM_RES" not in os.environ

--- a/tests/patch/platform/test_patch_vllm_registry.py
+++ b/tests/patch/platform/test_patch_vllm_registry.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import importlib.util
+import pickle
+import subprocess
+import sys
+import types
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+PATCH_PATH = ROOT / "ascend_vllm" / "patch" / "platform" / "patch_vllm_registry.py"
+
+
+# ---------------------------------------------------------------------------
+# Stub helpers — minimal ``vllm.model_executor.models.registry`` surface so
+# ``patch_vllm_registry.py`` can be imported in isolation. Only the symbols
+# the patch consults at import time are wired up; the rest fall back to plain
+# ``ModuleType`` package shells.
+# ---------------------------------------------------------------------------
+
+
+def _make_package(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module.__path__ = []  # type: ignore[attr-defined]
+    return module
+
+
+def _install_dependency_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> dict[str, Any]:
+    """Install stub modules for ``vllm`` and ``vllm.model_executor.models.registry``
+    so the patch module can be imported without the real vLLM runtime.
+
+    A unique sentinel is registered as the original ``_run_in_subprocess`` so
+    tests can prove the patch *actually replaced* the binding on import.
+    """
+    vllm = _make_package("vllm")
+    vllm_model_executor = _make_package("vllm.model_executor")
+    vllm_model_executor_models = _make_package("vllm.model_executor.models")
+
+    registry_mod = types.ModuleType("vllm.model_executor.models.registry")
+
+    # Sentinel — anything but the patched function. Used to prove the patch
+    # rewrote the attribute on import.
+    original_sentinel = object()
+    registry_mod._run_in_subprocess = original_sentinel  # type: ignore[attr-defined]
+    # The patch reads this constant at call time, not at import time, so a
+    # throwaway list is fine.
+    registry_mod._SUBPROCESS_COMMAND = ["python", "-c", "pass"]  # type: ignore[attr-defined]
+
+    monkeypatch.setitem(sys.modules, "vllm", vllm)
+    monkeypatch.setitem(sys.modules, "vllm.model_executor", vllm_model_executor)
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.models", vllm_model_executor_models)
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.models.registry", registry_mod)
+
+    # ``cloudpickle`` is imported lazily inside ``_run_in_subprocess`` and is
+    # not available in CI. Register a thin shim in ``sys.modules`` that
+    # delegates ``dumps``/``loads`` to stdlib ``pickle`` — sufficient for the
+    # simple callables and result values used by these tests.
+    cloudpickle_mod = types.ModuleType("cloudpickle")
+    cloudpickle_mod.dumps = pickle.dumps  # type: ignore[attr-defined]
+    cloudpickle_mod.loads = pickle.loads  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "cloudpickle", cloudpickle_mod)
+
+    return {
+        "registry_mod": registry_mod,
+        "original_sentinel": original_sentinel,
+        "cloudpickle": cloudpickle_mod,
+    }
+
+
+def _load_patch_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Any, dict[str, Any]]:
+    """Install stubs and import the patch module via importlib (isolated)."""
+    stubs = _install_dependency_stubs(monkeypatch)
+
+    module_name = f"patch_vllm_registry_under_test_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, PATCH_PATH)
+    assert spec is not None, "Could not build spec for patch_vllm_registry.py"
+    assert spec.loader is not None, "Spec has no loader"
+
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+
+    return module, stubs
+
+
+# ---------------------------------------------------------------------------
+# subprocess mocks — emulate what ``vllm.model_executor.models.registry._run``
+# would have written to the output file inside the real subprocess.
+# ---------------------------------------------------------------------------
+
+
+class _FakeCompletedProcess:
+    """Stand-in for ``subprocess.CompletedProcess`` used by the patch."""
+
+    def __init__(self, returncode: int, stderr: bytes = b"") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+
+    def check_returncode(self) -> None:
+        if self.returncode != 0:
+            raise subprocess.CalledProcessError(self.returncode, ["dummy"])
+
+
+def _make_subprocess_side_effect(
+    cloudpickle_mod: Any,
+    *,
+    returncode: int = 0,
+    output: Any = None,
+    stderr: bytes = b"",
+) -> Any:
+    """Build a ``subprocess.run`` replacement that mirrors what the real
+    subprocess worker does: unpickle ``(fn, output_filepath)``, write a
+    pickled result into ``output_filepath``, and return a CompletedProcess.
+
+    When ``returncode == 0`` and ``output is None``, the ``fn()`` result is
+    written (success path). When ``output`` is provided, it is written
+    instead —— useful for simulating a failed subprocess that still leaves
+    a partial result on disk (the patch's recovery scenario)
+    """
+
+    def _side_effect(*args: Any, **kwargs: Any) -> _FakeCompletedProcess:
+        input_bytes = kwargs.get("input")
+        assert input_bytes is not None, "subprocess.run must receive pickled input"
+        fn, output_filepath = cloudpickle_mod.loads(input_bytes)
+        result = output if output is not None else fn()
+        with open(output_filepath, "wb") as f:
+            f.write(pickle.dumps(result))
+        return _FakeCompletedProcess(returncode=returncode, stderr=stderr)
+
+    return _side_effect
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Module-level callables — used in place of lambdas so the stdlib ``pickle``
+# shim (substituted for ``cloudpickle``) can serialise them across the
+# mocked subprocess boundary.
+# ---------------------------------------------------------------------------
+
+
+def _ok_callable() -> Any:
+    """Return a fixed dict — module-level so stdlib ``pickle`` can serialise it."""
+
+    return {"status": "ok", "value": 1234}
+
+
+def _ignored_callable() -> Any:
+    """Return a tuple that the recovery-path test must NOT see."""
+
+    return ("this", "value", "ignored")
+
+
+class TestPatchVllmRegistry:
+    """Tests for the ``registry._run_in_subprocess`` override in
+    ``patch_vllm_registry.py``. Only the patch's semantic delta versus the
+    upstream vLLM ``registry._run_in_subprocess`` is exercised here.
+    """
+
+    def test_patch_replaces_run_in_subprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Importing the patch module rewrites ``registry._run_in_subprocess``
+        with the patched implementation — this is the patch's only side-effect.
+        """
+        # ``subprocess`` is referenced by the patch module via the stdlib
+        # binding; supply a MagicMock so importing doesn't attempt any work.
+        monkeypatch.setattr(subprocess, "run", MagicMock())
+
+        module, stubs = _load_patch_module(monkeypatch)
+        registry_mod = stubs["registry_mod"]
+
+        # The sentinel we registered before import must have been replaced
+        # with the function defined inside the patch module.
+        assert registry_mod._run_in_subprocess is not stubs["original_sentinel"]
+        assert registry_mod._run_in_subprocess is module._run_in_subprocess
+
+        # And the new binding must NOT be the original upstream function — the
+        # patch's whole point is to substitute a different implementation.
+        assert callable(registry_mod._run_in_subprocess)
+        assert registry_mod._run_in_subprocess.__module__ == module.__name__
+        assert registry_mod._run_in_subprocess.__qualname__ == "_run_in_subprocess"
+
+    def test_returns_fn_result_when_subprocess_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Happy path — when the subprocess exits 0, the patched
+        ``_run_in_subprocess`` reads the pickled result from the output file
+        and returns whatever ``fn()`` produced."""
+        module, stubs = _load_patch_module(monkeypatch)
+        cloudpickle_mod = stubs["cloudpickle"]
+
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            _make_subprocess_side_effect(cloudpickle_mod),
+        )
+
+        result = module._run_in_subprocess(_ok_callable)
+
+        assert result == {"status": "ok", "value": 1234}
+        # The callable was transported through the stdlib pickle shim
+        # end-to-end and its return value was round-tripped via the
+        # mocked subprocess output file.
+
+    def test_recovers_partial_output_when_subprocess_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Recovery path (the patch's distinguishing behavior) — when the
+        subprocess exits non-zero but a pickled result is still on disk, the
+        patched function returns that result instead of raising ``RuntimeError``.
+
+        This is the behavior the patch ADDS versus the upstream implementation,
+        which unconditionally raises on a non-zero return code.
+        """
+        module, stubs = _load_patch_module(monkeypatch)
+        cloudpickle_mod = stubs["cloudpickle"]
+
+        partial = ["partial", "result", "from", "subprocess"]
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            _make_subprocess_side_effect(cloudpickle_mod, returncode=1, output=partial, stderr=b"simulated failure"),
+        )
+
+        # Must NOT raise RuntimeError; must return the partial result.
+        result = module._run_in_subprocess(_ignored_callable)
+
+        assert result == partial
+        # And the returncode-1 scenario is genuinely exercised: if the patch
+        # were to fall through to ``raise RuntimeError`` instead of recovering,
+        # this assertion would never run.
+        assert result[0] == "partial"

--- a/tests/patch/worker/test_patch_deepseek_v4_dspark.py
+++ b/tests/patch/worker/test_patch_deepseek_v4_dspark.py
@@ -1,0 +1,498 @@
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+import types
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+PATCH_PATH = ROOT / "ascend_vllm" / "patch" / "worker" / "patch_deepseek_v4_dspark.py"
+
+
+# ---------------------------------------------------------------------------
+# Stub helpers — minimal vllm / vllm_ascend / torch surface that the patch
+# module imports at load time. Behaviour is only configured on the symbols
+# that the patched ``load_weights`` actually consults at runtime; everything
+# else falls back to ``MagicMock`` auto-spec.
+# ---------------------------------------------------------------------------
+
+
+def _make_package(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module.__path__ = []  # type: ignore[attr-defined]
+    return module
+
+
+def _install_stubs(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Install stub modules so ``patch_deepseek_v4_dspark.py`` can be
+    imported without the real vLLM / vLLM-Ascend runtime being present."""
+
+    torch_mod = MagicMock(name="torch")
+    torch_mod.__name__ = "torch"
+    torch_mod.__path__ = []
+    torch_mod.float8_e8m0fnu = "float8_e8m0fnu"
+    torch_mod.uint8 = "uint8"
+
+    def _view(_self, dtype):  # used by ``loaded_weight.view(torch.uint8)``
+        return ("viewed", dtype)
+
+    torch_mod.Tensor.view = _view
+
+    npu_mod = MagicMock(name="torch.npu")
+    npu_mod.__name__ = "torch.npu"
+
+    torch_npu_mod = MagicMock(name="torch_npu")
+    torch_npu_mod.__name__ = "torch_npu"
+
+    # vllm.distributed — TP rank / world_size are read inside load_weights.
+    vllm = _make_package("vllm")
+    vllm_distributed = types.ModuleType("vllm.distributed")
+    vllm_distributed.get_tensor_model_parallel_rank = MagicMock(return_value=0)  # type: ignore[attr-defined]
+    vllm_distributed.get_tensor_model_parallel_world_size = MagicMock(return_value=1)  # type: ignore[attr-defined]
+
+    # vllm.logger — info_once / warning_once only need to swallow the call.
+    vllm_logger_mod = types.ModuleType("vllm.logger")
+    vllm_logger_inst = MagicMock(name="logger")
+    vllm_logger_mod.logger = vllm_logger_inst  # type: ignore[attr-defined]
+
+    # vllm.model_executor.model_loader.weight_utils
+    vllm_me_pkg = _make_package("vllm.model_executor")
+    vllm_me_mod_pkg = _make_package("vllm.model_executor.model_loader")
+    vllm_weight_utils = types.ModuleType("vllm.model_executor.model_loader.weight_utils")
+
+    def _default_weight_loader(param, weight):  # identity copy marker
+        param._loaded_with = getattr(param, "_loaded_with", []) + [weight]
+        return None
+
+    vllm_weight_utils.default_weight_loader = _default_weight_loader  # type: ignore[attr-defined]
+
+    # vllm_ascend.models.deepseek_v4_dspark
+    vllm_ascend = _make_package("vllm_ascend")
+    vllm_ascend_models = _make_package("vllm_ascend.models")
+    dspark_mod = types.ModuleType("vllm_ascend.models.deepseek_v4_dspark")
+
+    class _DSparkDeepseekV4ForCausalLM:
+        """Stand-in target class. Tests replace ``load_weights`` after the
+        patch binds it via importlib."""
+
+        # Set by ``_build_dspark_self`` before invoking ``load_weights``.
+        pass
+
+    # _EXPERT_SCALE_RE matches names like ``*.experts.<id>.<proj>.scale``
+    dspark_mod._EXPERT_SCALE_RE = re.compile(r"\.experts\.\d+\.[A-Za-z_]+\.scale$")  # type: ignore[attr-defined]
+    dspark_mod.DSparkDeepseekV4ForCausalLM = _DSparkDeepseekV4ForCausalLM  # type: ignore[attr-defined]
+
+    # Register stubs.
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    monkeypatch.setitem(sys.modules, "torch.npu", npu_mod)
+    monkeypatch.setitem(sys.modules, "torch_npu", torch_npu_mod)
+    monkeypatch.setitem(sys.modules, "vllm", vllm)
+    monkeypatch.setitem(sys.modules, "vllm.distributed", vllm_distributed)
+    monkeypatch.setitem(sys.modules, "vllm.logger", vllm_logger_mod)
+    monkeypatch.setitem(sys.modules, "vllm.model_executor", vllm_me_pkg)
+    monkeypatch.setitem(sys.modules, "vllm.model_executor.model_loader", vllm_me_mod_pkg)
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.model_loader.weight_utils",
+        vllm_weight_utils,
+    )
+    monkeypatch.setitem(sys.modules, "vllm_ascend", vllm_ascend)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.models", vllm_ascend_models)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.models.deepseek_v4_dspark", dspark_mod)
+
+    return {
+        "torch_mod": torch_mod,
+        "vllm_logger_inst": vllm_logger_inst,
+        "default_weight_loader": _default_weight_loader,
+        "DSparkDeepseekV4ForCausalLM": _DSparkDeepseekV4ForCausalLM,
+        "dspark_mod": dspark_mod,
+    }
+
+
+def _load_patch_module(monkeypatch: pytest.MonkeyPatch):
+    """Install stubs and import the patch module via importlib (isolation)."""
+    stubs = _install_stubs(monkeypatch)
+
+    module_name = f"patch_deepseek_v4_dspark_under_test_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, PATCH_PATH)
+    assert spec is not None, "Could not build spec for patch_deepseek_v4_dspark.py"
+    assert spec.loader is not None, "Spec has no loader"
+
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+
+    return module, stubs
+
+
+# ---------------------------------------------------------------------------
+# Builder helpers — produce minimal ``self`` mocks that drive the patched
+# ``load_weights`` down specific code paths.
+# ---------------------------------------------------------------------------
+
+
+def _build_dspark_self(
+    stubs: dict[str, Any],
+    *,
+    expert_dtype: str | None = None,
+    num_attention_heads: int = 4,
+    has_own_embed_tokens: bool = False,
+    has_own_lm_head: bool = False,
+    remap: dict[str, str | None] | None = None,
+    expert_mapping: list[tuple[str, str, int, int]] | None = None,
+    params: dict[str, Any] | None = None,
+) -> Any:
+    """Assemble a self-mock that exercises one ``load_weights`` invocation."""
+    cls = stubs["DSparkDeepseekV4ForCausalLM"]
+    self_obj = cls()
+
+    config = MagicMock(name="config")
+    # ``getattr(self.config, "expert_dtype", "fp4")`` must work; default fp4
+    # if not explicitly provided.
+    if expert_dtype is None:
+        config.expert_dtype = "fp4"
+    else:
+        config.expert_dtype = expert_dtype
+    config.num_attention_heads = num_attention_heads
+    self_obj.config = config
+
+    self_obj.has_own_embed_tokens = has_own_embed_tokens
+    self_obj.has_own_lm_head = has_own_lm_head
+
+    self_obj.model = MagicMock(name="model")
+    self_obj.model.get_expert_mapping = MagicMock(return_value=expert_mapping or [])
+
+    remap = remap or {}
+
+    def _remap(name: str) -> str | None:
+        return remap.get(name, name)
+
+    self_obj._remap_dspark_name = _remap
+
+    self_obj.named_parameters = MagicMock(return_value=params or {})
+
+    return self_obj
+
+
+def _make_param(
+    name: str,
+    *,
+    weight_loader=None,
+) -> Any:
+    """Build a stand-in for a module parameter.
+
+    A parameter with a custom ``weight_loader`` (callable) gets it stored so
+    the patched method can invoke it.
+    """
+    param = MagicMock(name=f"param[{name}]")
+    param._param_name = name
+    if weight_loader is not None:
+        param.weight_loader = weight_loader
+    return param
+
+
+def _make_weight(name: str = "tensor") -> Any:
+    """Build a stand-in for a checkpoint tensor with a ``dtype`` attribute.
+
+    The patch only reads ``loaded_weight.dtype`` and (for E8M0 scales)
+    ``loaded_weight.view(...)``. A plain ``MagicMock`` with a sentinel
+    ``dtype`` attribute is sufficient.
+    """
+    weight = MagicMock(name=name)
+    weight.dtype = "fp32"  # not float8_e8m0fnu → E8M0 branch skipped
+    return weight
+
+
+# ---------------------------------------------------------------------------
+# Tests — only the behavioural surface introduced by the patch.
+# ---------------------------------------------------------------------------
+
+
+class TestPatchDeepseekV4Dspark:
+    """Tests for ``patch_deepseek_v4_dspark.py``.
+
+    The patch replaces ``DSparkDeepseekV4ForCausalLM.load_weights`` with an
+    Ascend-aware implementation tailored for the A5 dSpark draft loader.
+    The following behaviours are verified:
+
+    1. Module import monkey-patches ``load_weights`` onto the target class.
+    2. ``embed.weight`` / ``head.weight`` are remapped to the canonical
+       ``model.embed_tokens.weight`` / ``lm_head.weight`` names whenever
+       the dSpark draft does not own its own embedding / head weights.
+    3. The ``.scale`` suffix of expert weights is rewritten according to
+       the dtype branch (``fp4`` → ``.weight_scale``,
+       otherwise → ``.weight_scale_inv``); non-expert scales stay on the
+       ``.weight_scale`` Ascend convention.
+    4. ``.experts.*`` weights are routed through ``expert_mapping`` and
+       the corresponding ``weight_loader`` is invoked with the right
+       ``expert_id`` and ``shard_id``.
+    """
+
+    # ------------------------------------------------------------------ #
+    # 1. Installation                                                    #
+    # ------------------------------------------------------------------ #
+    def test_patch_installs_load_weights_on_dspark_class(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Importing the patch module must rebind ``load_weights`` on
+        ``DSparkDeepseekV4ForCausalLM`` to the patched function."""
+        module, stubs = _load_patch_module(monkeypatch)
+        cls = stubs["DSparkDeepseekV4ForCausalLM"]
+
+        assert cls.load_weights is module.load_weights, (
+            "patch_deepseek_v4_dspark.py did not bind load_weights onto DSparkDeepseekV4ForCausalLM"
+        )
+
+    # ------------------------------------------------------------------ #
+    # 2. Embed / head weight remap                                       #
+    # ------------------------------------------------------------------ #
+    def test_load_weights_remaps_embed_and_head_when_not_owned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``embed.weight`` and ``head.weight`` must be translated to the
+        canonical model-level parameter names when the dSpark draft does
+        NOT own its own embedding / LM head."""
+        _module, stubs = _load_patch_module(monkeypatch)
+
+        loaded: list[tuple[str, Any]] = []
+
+        def _capturing_loader(param, weight, **_kw):
+            loaded.append((param._param_name, weight))
+
+        params = {
+            "model.embed_tokens.weight": _make_param("model.embed_tokens.weight", weight_loader=_capturing_loader),
+            "lm_head.weight": _make_param("lm_head.weight", weight_loader=_capturing_loader),
+        }
+        self_obj = _build_dspark_self(
+            stubs,
+            expert_dtype="fp4",
+            has_own_embed_tokens=False,
+            has_own_lm_head=False,
+            params=params,
+        )
+
+        weights = [
+            ("embed.weight", _make_weight("embed_tensor")),
+            ("head.weight", _make_weight("head_tensor")),
+        ]
+        loaded_params = self_obj.load_weights(weights)
+
+        # Both names must have been routed to the canonical model paths.
+        assert ("model.embed_tokens.weight", weights[0][1]) in loaded
+        assert ("lm_head.weight", weights[1][1]) in loaded
+        assert "model.embed_tokens.weight" in loaded_params
+        assert "lm_head.weight" in loaded_params
+
+    # ------------------------------------------------------------------ #
+    # 3. Expert scale suffix branches on expert_dtype                    #
+    # ------------------------------------------------------------------ #
+    def test_load_weights_uses_fp4_weight_scale_suffix_only_when_expert_dtype_fp4(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The patch rewrites ``.scale`` → ``.weight_scale`` when
+        ``expert_dtype == 'fp4'`` and → ``.weight_scale_inv`` otherwise
+        (matched via ``_EXPERT_SCALE_RE``). Non-expert scales keep the
+        Ascend ``.weight_scale`` convention regardless of dtype."""
+        _module, stubs = _load_patch_module(monkeypatch)
+
+        captured: list[str] = []
+
+        def _capturing_loader(param, _weight, name_mapped=None, **_kw):
+            captured.append(param._param_name)
+            return True
+
+        # One expert-quantized scale and one non-expert scale. The expert
+        # one needs to be reachable through ``expert_mapping`` so the
+        # loader actually fires — otherwise the patch's ``continue``
+        # silently drops the weight.
+        expert_param = _make_param(
+            "model.layers.0.mlp.experts.<M>.gate_proj.weight_scale_inv",
+            weight_loader=_capturing_loader,
+        )
+        expert_param_fp4 = _make_param(
+            "model.layers.0.mlp.experts.<M>.gate_proj.weight_scale",
+            weight_loader=_capturing_loader,
+        )
+        non_expert_param = _make_param(
+            "model.layers.0.self_attn.q_proj.weight_scale",
+            weight_loader=_capturing_loader,
+        )
+
+        # ---- branch 1: expert_dtype != 'fp4' ---------------------------
+        # expert scale must end up as ``.weight_scale_inv``;
+        # non-expert scale must keep ``.weight_scale``.
+        expert_mapping_non_fp4 = [
+            (
+                "model.layers.0.mlp.experts.<M>.gate_proj.weight_scale_inv",
+                "model.layers.0.mlp.experts.0.gate_proj.weight_scale_inv",
+                0,
+                0,
+            ),
+        ]
+        params_non_fp4 = {
+            expert_param._param_name: expert_param,
+            non_expert_param._param_name: non_expert_param,
+        }
+        self_obj = _build_dspark_self(
+            stubs,
+            expert_dtype="mx",
+            num_attention_heads=1,
+            params=params_non_fp4,
+            expert_mapping=expert_mapping_non_fp4,
+        )
+
+        loaded_params = self_obj.load_weights(
+            [
+                (
+                    "model.layers.0.mlp.experts.0.gate_proj.scale",
+                    _make_weight("expert_scale"),
+                ),
+                (
+                    "model.layers.0.self_attn.q_proj.scale",
+                    _make_weight("attn_scale"),
+                ),
+            ]
+        )
+
+        assert "model.layers.0.mlp.experts.<M>.gate_proj.weight_scale_inv" in loaded_params
+        assert "model.layers.0.self_attn.q_proj.weight_scale" in loaded_params
+        assert captured == [
+            "model.layers.0.mlp.experts.<M>.gate_proj.weight_scale_inv",
+            "model.layers.0.self_attn.q_proj.weight_scale",
+        ]
+
+        # ---- branch 2: expert_dtype == 'fp4' ---------------------------
+        # expert scale must end up as ``.weight_scale`` (NOT ``_inv``).
+        captured.clear()
+        expert_mapping_fp4 = [
+            (
+                "model.layers.0.mlp.experts.<M>.gate_proj.weight_scale",
+                "model.layers.0.mlp.experts.0.gate_proj.weight_scale",
+                0,
+                0,
+            ),
+        ]
+        self_obj_fp4 = _build_dspark_self(
+            stubs,
+            expert_dtype="fp4",
+            num_attention_heads=1,
+            params={expert_param_fp4._param_name: expert_param_fp4},
+            expert_mapping=expert_mapping_fp4,
+        )
+        loaded_params_fp4 = self_obj_fp4.load_weights(
+            [
+                (
+                    "model.layers.0.mlp.experts.0.gate_proj.scale",
+                    _make_weight("expert_scale"),
+                ),
+            ]
+        )
+        assert "model.layers.0.mlp.experts.<M>.gate_proj.weight_scale" in loaded_params_fp4
+        assert captured == ["model.layers.0.mlp.experts.<M>.gate_proj.weight_scale"]
+
+    # ------------------------------------------------------------------ #
+    # 4. Expert weight routing through expert_mapping                    #
+    # ------------------------------------------------------------------ #
+    def test_load_weights_routes_experts_through_expert_mapping(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``*.experts.*`` weights must be dispatched via
+        ``self.model.get_expert_mapping()``; the destination
+        ``weight_loader`` must be called with ``expert_id`` and
+        ``shard_id`` from the matching mapping entry, and the resulting
+        parameter name must be tracked in ``loaded_params``."""
+        _module, stubs = _load_patch_module(monkeypatch)
+
+        captured: list[dict[str, Any]] = []
+
+        def _capturing_loader(param, weight, name_mapped=None, *, shard_id, expert_id, return_success, **_kw):
+            captured.append(
+                {
+                    "param": param._param_name,
+                    "weight": weight,
+                    "shard_id": shard_id,
+                    "expert_id": expert_id,
+                    "return_success": return_success,
+                }
+            )
+            return True
+
+        target_param = _make_param("model.layers.0.mlp.experts.<M>.w13", weight_loader=_capturing_loader)
+
+        # ``weight_name`` must be a substring of the checkpoint name, and
+        # ``name.replace(weight_name, param_name)`` must yield a key that
+        # is present in ``params_dict``.
+        expert_mapping = [
+            (
+                "model.layers.0.mlp.experts.<M>.w13",
+                "model.layers.0.mlp.experts.0.w13",
+                0,
+                0,
+            ),  # shard 0 of expert 0
+            (
+                "model.layers.0.mlp.experts.<M>.w13",
+                "model.layers.0.mlp.experts.0.w13",
+                0,
+                1,
+            ),  # shard 1 of expert 0
+            (
+                "model.layers.0.mlp.experts.<M>.w2",
+                "model.layers.0.mlp.experts.0.w2",
+                0,
+                0,
+            ),
+        ]
+
+        self_obj = _build_dspark_self(
+            stubs,
+            expert_dtype="fp4",
+            params={target_param._param_name: target_param},
+            expert_mapping=expert_mapping,
+        )
+
+        weights = [("model.layers.0.mlp.experts.0.w13", _make_weight("expert_w13"))]
+        loaded_params = self_obj.load_weights(weights)
+
+        # Exactly one expert call: routed to (expert_id=0, shard_id=0)
+        # because that is the first mapping entry whose weight_name is in
+        # the checkpoint name and the loader returns success.
+        assert len(captured) == 1
+        call = captured[0]
+        assert call["param"] == "model.layers.0.mlp.experts.<M>.w13"
+        assert call["weight"] == weights[0][1]
+        assert call["expert_id"] == 0
+        assert call["shard_id"] == 0
+        assert call["return_success"] is True
+        assert "model.layers.0.mlp.experts.<M>.w13" in loaded_params
+
+    # ------------------------------------------------------------------ #
+    # 5. Skip params not in model (patch delta)                          #
+    # ------------------------------------------------------------------ #
+    def test_load_weights_skips_params_not_in_model(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When a weight name from the checkpoint does not exist in params_dict,
+        the patched load_weights should skip it gracefully (via logger.warning_once)
+        instead of crashing with KeyError —— the patch's core delta."""
+        _module, stubs = _load_patch_module(monkeypatch)
+
+        # Build self with only a few params —— NOT includeing the weight name we'll pass
+        params = {
+            "model.embed_tokens.weight": _make_param("model.embed_tokens.weight"),
+        }
+        self_obj = _build_dspark_self(
+            stubs,
+            expert_dtype="fp4",
+            params=params,
+        )
+
+        # This weight name won't be in params_dict
+        weights = [
+            ("model.layers.0.self_attn.q_proj.weight", _make_weight("missing_param")),
+        ]
+
+        # Should NOT raise KeyError —— the patch adds a guard
+        loaded_params = self_obj.load_weights(weights)
+
+        assert "model.layers.0.self_attn.q_proj.weight" not in loaded_params
+
+        # Verify logger.warning_once was called
+        stubs["vllm_logger_inst"].warning_once.assert_called()

--- a/tests/patch/worker/test_patch_fused_moe.py
+++ b/tests/patch/worker/test_patch_fused_moe.py
@@ -1,0 +1,579 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+PATCH_PATH = ROOT / "ascend_vllm" / "patch" / "worker" / "patch_fused_moe.py"
+
+
+def _make_package(name: str) -> types.ModuleType:
+    module = types.ModuleType(name)
+    module.__path__ = []  # type: ignore[attr-defined]
+    return module
+
+
+class _Event:
+    """Sentinel event with a distinguishable identity for ``wait_event`` tracking."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid only
+        return f"_Event({self.name!r})"
+
+
+class _RecordingStream:
+    """Mock NPU stream that records every ``wait_event`` invocation."""
+
+    def __init__(self) -> None:
+        self.waited_events: list[Any] = []
+
+    def wait_event(self, evt) -> None:
+        self.waited_events.append(evt)
+
+    def wait_stream(self, _stream) -> None:  # pragma: no cover - structural
+        pass
+
+    def record_event(self):  # pragma: no cover - structural
+        return _Event("recorded")
+
+
+def _install_stubs(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Install stub modules for ``torch`` / ``torch_npu`` / ``vllm`` /
+    ``vllm_ascend`` so that ``patch_fused_moe.py`` can be imported in isolation.
+
+    The patch module imports several symbols at module load time; only the
+    surface used during ``_forward_shared_experts`` execution is given
+    functioning behaviour. Everything else falls back to ``MagicMock``.
+    """
+    # --- torch / torch.npu ------------------------------------------------
+    torch_mod = MagicMock()
+    torch_mod.__name__ = "torch"
+    torch_mod.__path__ = []
+    torch_mod.float16 = "float16"
+    torch_mod.float8_e4m3fn = "float8_e4m3fn"
+    # The patched code writes ``output_dtype=torch.int32`` and
+    # ``output_dtype=original_dtype``; int32 is read as an attribute, so
+    # give it a sentinel value rather than letting MagicMock autogenerate.
+    torch_mod.int32 = "int32"
+
+    npu_mod = MagicMock()
+    npu_mod.__name__ = "torch.npu"
+
+    shared_stream = _RecordingStream()
+    npu_mod.current_stream = MagicMock(return_value=shared_stream)
+
+    # CRITICAL: ``patch_fused_moe.py`` accesses the npu submodule as
+    # ``torch.npu.current_stream()`` — not as ``import torch.npu``. Because
+    # ``torch_mod`` is a MagicMock, ``torch_mod.npu`` would auto-generate a
+    # child mock by default; binding our prepared ``npu_mod`` here ensures
+    # attribute lookups land on the same instance that holds the recording
+    # stream, the ``current_stream`` return-value, and any op mocks the
+    # individual tests register under ``stubs["torch_mod"].ops._C_ascend.*``.
+    torch_mod.npu = npu_mod
+
+    # --- torch_npu --------------------------------------------------------
+    torch_npu_mod = MagicMock()
+    torch_npu_mod.__name__ = "torch_npu"
+    torch_npu_mod.npu_dynamic_quant = MagicMock(return_value=(MagicMock(), MagicMock()))
+    torch_npu_mod.npu_dynamic_mx_quant = MagicMock(return_value=(MagicMock(), MagicMock()))
+    # ``npu_quant_matmul`` is invoked twice on the int-quant path; let it
+    # return a fresh MagicMock per call so call-count assertions work.
+    torch_npu_mod.npu_quant_matmul = MagicMock(side_effect=lambda *_a, **_kw: MagicMock())
+
+    # --- vllm -------------------------------------------------------------
+    vllm = _make_package("vllm")
+    vllm_distributed = types.ModuleType("vllm.distributed")
+    vllm_distributed.tensor_model_parallel_all_reduce = MagicMock(  # type: ignore[attr-defined]
+        side_effect=lambda x: x  # identity passthrough for the reduce path
+    )
+
+    # --- vllm_ascend ------------------------------------------------------
+    vllm_ascend = _make_package("vllm_ascend")
+    vllm_ascend_ops = _make_package("vllm_ascend.ops")
+    vllm_ascend_ops_fused_moe = _make_package("vllm_ascend.ops.fused_moe")
+
+    class _AscendMoERunner:
+        # The patch installs ``_forward_shared_experts`` as a class attribute.
+        # Test code calls it via the class to verify monkey-patching.
+        pass
+
+    class _FusedMoEEvents:
+        """Stand-in for ``FusedMoEEvents`` — accepts arbitrary kwargs and
+        exposes them as attributes. Mirrors the dataclass in ``fused_moe.py``
+        just enough to drive the patched method."""
+
+        def __init__(self, **kwargs) -> None:
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    fused_moe_mod = types.ModuleType("vllm_ascend.ops.fused_moe.fused_moe")
+    fused_moe_mod.AscendMoERunner = _AscendMoERunner  # type: ignore[attr-defined]
+    fused_moe_mod.FusedMoEEvents = _FusedMoEEvents  # type: ignore[attr-defined]
+
+    # ascend_forward_context
+    class _MoECommType:
+        ALLTOALL = "ALLTOALL"
+        MC2 = "MC2"
+        FUSED_MC2 = "FUSED_MC2"
+        ALLGATHER = "ALLGATHER"
+
+    class _ExtraCtx:
+        # Default to ALLGATHER so the all-reduce path is bypassed by default.
+        moe_comm_type = "ALLGATHER"
+
+    ascend_fwd_mod = types.ModuleType("vllm_ascend.ascend_forward_context")
+    ascend_fwd_mod._EXTRA_CTX = _ExtraCtx()  # type: ignore[attr-defined]
+    ascend_fwd_mod.MoECommType = _MoECommType  # type: ignore[attr-defined]
+
+    # quant_type
+    class _QuantType:
+        NONE = "NONE"
+        W8A8 = "W8A8"
+        W4A8 = "W4A8"
+        W4A8MXFP = "W4A8MXFP"
+
+    quant_pkg = _make_package("vllm_ascend.quantization")
+    quant_mod = types.ModuleType("vllm_ascend.quantization.quant_type")
+    quant_mod.QuantType = _QuantType  # type: ignore[attr-defined]
+
+    # utils
+    class _NoOpStreamSwitch:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+    utils_mod = types.ModuleType("vllm_ascend.utils")
+    utils_mod.npu_stream_switch = _NoOpStreamSwitch  # type: ignore[attr-defined]
+    utils_mod.shared_expert_dp_enabled = MagicMock(return_value=False)  # type: ignore[attr-defined]
+    utils_mod.shared_experts_calculation_stream = MagicMock(return_value=object())  # type: ignore[attr-defined]
+
+    # Register all stubs.
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    monkeypatch.setitem(sys.modules, "torch.npu", npu_mod)
+    monkeypatch.setitem(sys.modules, "torch_npu", torch_npu_mod)
+    monkeypatch.setitem(sys.modules, "vllm", vllm)
+    monkeypatch.setitem(sys.modules, "vllm.distributed", vllm_distributed)
+    monkeypatch.setitem(sys.modules, "vllm_ascend", vllm_ascend)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.ops", vllm_ascend_ops)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.ops.fused_moe", vllm_ascend_ops_fused_moe)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.ops.fused_moe.fused_moe", fused_moe_mod)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.ascend_forward_context", ascend_fwd_mod)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.quantization", quant_pkg)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.quantization.quant_type", quant_mod)
+    monkeypatch.setitem(sys.modules, "vllm_ascend.utils", utils_mod)
+
+    return {
+        "torch_mod": torch_mod,
+        "torch_npu_mod": torch_npu_mod,
+        "npu_mod": npu_mod,
+        "AscendMoERunner": _AscendMoERunner,
+        "FusedMoEEvents": _FusedMoEEvents,
+        "MoECommType": _MoECommType,
+        "QuantType": _QuantType,
+        "shared_stream": shared_stream,
+        "extra_ctx": _ExtraCtx,
+    }
+
+
+def _load_patch_module(monkeypatch: pytest.MonkeyPatch):
+    """Install stubs and import the patch module via importlib (isolation)."""
+    stubs = _install_stubs(monkeypatch)
+
+    module_name = f"patch_fused_moe_under_test_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, PATCH_PATH)
+    assert spec is not None, "Could not build spec for patch_fused_moe.py"
+    assert spec.loader is not None, "Spec has no loader"
+
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+
+    return module, stubs
+
+
+def _make_unquantized_shared_experts() -> Any:
+    """Build a ``_shared_experts`` mock with NO ``weight_scale`` attributes,
+    forcing the patched method into its non-quantized ``else`` branch."""
+
+    class _Proj:
+        pass  # bare — no weight_scale, so ``hasattr(...)`` is False
+
+    class _SharedExperts:
+        def __init__(self) -> None:
+            self.gate_up_proj = _Proj()
+            self.down_proj = _Proj()
+
+    return _SharedExperts()
+
+
+def _make_w4a8mxfp_shared_experts() -> Any:
+    """Build a ``_shared_experts`` mock with ``weight_scale`` attributes for
+    the W4A8MXFP branch. ``gate_up_proj`` and ``down_proj`` are callables
+    that return ``[output_tensor]`` (they are called with a (qx, scale)
+    tuple and indexed at ``[0]``)."""
+
+    def _proj_factory(prefix: str) -> MagicMock:
+        proj = MagicMock(name=f"{prefix}_proj")
+        proj.weight_scale = "mx_scale"
+        proj.weight_scale_fp32 = "scale_fp32"  # presence forces has_quantized_shared
+        proj.weight = "mx_weight"
+        proj.return_value = [MagicMock(name=f"mx_{prefix}_out")]
+        return proj
+
+    return type(
+        "_SharedExperts",
+        (),
+        {
+            "gate_up_proj": _proj_factory("gate_up"),
+            "down_proj": _proj_factory("down"),
+        },
+    )()
+
+
+def _make_int_quant_shared_experts() -> Any:
+    """Build a ``_shared_experts`` mock with ``weight_scale`` attributes for
+    the W8A8/W4A8 int-quant branch.
+
+    The int-quant path accesses ``weight`` / ``weight_scale`` /
+    ``weight_scale_fp32`` as ATTRIBUTES only — never invokes the projections
+    as callables. Returning sentinel strings is enough.
+    """
+
+    def _proj_factory() -> MagicMock:
+        proj = MagicMock(name="int_proj")
+        proj.weight_scale = "int_scale"
+        proj.weight = "int_weight"
+        proj.weight_scale_fp32 = "int_scale_fp32"
+        return proj
+
+    return type(
+        "_SharedExperts",
+        (),
+        {
+            "gate_up_proj": _proj_factory(),
+            "down_proj": _proj_factory(),
+        },
+    )()
+
+
+class _Hidden:
+    """Mock hidden_states tensor with dtype attribute."""
+
+    dtype = "float16"
+
+
+def _run_w4a8mxfp_forward(stubs: dict[str, Any]) -> tuple[Any, Any, Any, Any]:
+    """Set up and execute the W4A8MXFP branch of ``_forward_shared_experts``.
+
+    Returns ``(swiglu_calls, result, shared_experts, evts)`` where:
+    - ``swiglu_calls`` captures all kwargs passed to ``npu_swiglu_shared_quant``
+    - ``result`` is the return value of ``_forward_shared_experts``
+    - ``shared_experts`` is the mock shared experts object (for call assertions)
+    - ``evts`` is the ``FusedMoEEvents`` used (for event-wait assertions)
+    """
+    cls = stubs["AscendMoERunner"]
+    QuantType = stubs["QuantType"]
+    FusedMoEEvents = stubs["FusedMoEEvents"]
+
+    evts = FusedMoEEvents(
+        before_routed_experts=_Event("before_routed_experts"),
+        after_routed_experts=_Event("after_routed_experts"),
+        before_dispatch=_Event("before_dispatch"),
+        before_gmm2=_Event("before_gmm2"),
+        before_combine=_Event("before_combine"),
+        swiglu_limit=0.5,
+        swiglu_alpha=0.7,
+        swiglu_beta=0.2,
+    )
+
+    swiglu_calls: list[Any] = []
+
+    def _swiglu(*_args, **kwargs):
+        swiglu_calls.append(kwargs)
+        return (MagicMock(name="qx_after_swiglu"), MagicMock(name="scale_after_swiglu"), None)
+
+    stubs["torch_mod"].ops._C_ascend.npu_swiglu_group_quant = MagicMock(side_effect=_swiglu)
+
+    shared_experts = _make_w4a8mxfp_shared_experts()
+    mock_self = MagicMock()
+    mock_self._shared_experts = shared_experts
+    mock_self.quant_type = QuantType.W4A8MXFP
+    mock_self.multistream_overlap_shared_expert = False
+
+    result = cls._forward_shared_experts(mock_self, _Hidden(), evts)
+    return swiglu_calls, result, shared_experts, evts
+
+
+class TestPatchFusedMoe:
+    """Tests for ``patch_fused_moe.py`` — the patched
+    ``AscendMoERunner._forward_shared_experts`` method.
+
+    The patch introduces ONE behavioural delta:
+
+    * In the ``W4A8MXFP`` branch, the call to
+      ``torch.ops._C_ascend.npu_swiglu_group_quant(...)`` no longer
+      forwards the ``glu_alpha`` and ``glu_bias`` keyword arguments
+      (the values of ``fused_moe_evts.swiglu_alpha`` and
+      ``fused_moe_evts.swiglu_beta`` are no longer mapped onto those
+      parameter names).
+    """
+
+    # ------------------------------------------------------------------ #
+    # 1. Installation                                                    #
+    # ------------------------------------------------------------------ #
+    def test_patch_installs_forward_shared_experts_on_ascend_moe_runner(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Loading ``patch_fused_moe`` must attach ``_forward_shared_experts``
+        as a class attribute on ``AscendMoERunner`` (monkey-patch)."""
+        module, stubs = _load_patch_module(monkeypatch)
+
+        cls = stubs["AscendMoERunner"]
+        assert cls._forward_shared_experts is module._forward_shared_experts, (
+            "patch_fused_moe.py did not bind _forward_shared_experts to the AscendMoERunner class"
+        )
+
+    # ------------------------------------------------------------------ #
+    # 2. PATCH DELTA — W4A8MXFP drops glu_alpha and glu_bias              #
+    # ------------------------------------------------------------------ #
+    def test_w4a8mxfp_branch_swiglu_group_quant_omits_glu_alpha_and_glu_bias(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """In the ``W4A8MXFP`` branch the ``npu_swiglu_group_quant`` op is
+        called WITHOUT the ``glu_alpha`` and ``glu_bias`` kwargs — the
+        patch's only behavioural change."""
+        _module, stubs = _load_patch_module(monkeypatch)
+        swiglu_calls, _result, _shared_experts, evts = _run_w4a8mxfp_forward(stubs)
+
+        # The op must have been invoked exactly once.
+        assert len(swiglu_calls) == 1, f"expected exactly one npu_swiglu_group_quant call, got {len(swiglu_calls)}"
+        kwargs = swiglu_calls[0]
+
+        # PATCH DELTA: glu_alpha and glu_bias must NOT appear in the kwargs
+        # forwarded to npu_swiglu_group_quant. Note that the upstream
+        # code's signature also did not accept these arguments (which
+        # makes them silently-drops — the patch aligns the call site
+        # with the actual op signature).
+        assert "glu_alpha" not in kwargs, (
+            f"PATCH DELTA: glu_alpha was unexpectedly forwarded to npu_swiglu_group_quant: {kwargs!r}"
+        )
+        assert "glu_bias" not in kwargs, (
+            f"PATCH DELTA: glu_bias was unexpectedly forwarded to npu_swiglu_group_quant: {kwargs!r}"
+        )
+
+    # ------------------------------------------------------------------ #
+    # 3. Regression — preserved kwargs on npu_swiglu_group_quant         #
+    # ------------------------------------------------------------------ #
+    def test_w4a8mxfp_branch_swiglu_group_quant_preserves_required_kwargs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ``clamp_value``, ``dst_type``, ``quant_mode``, ``topk_weight``
+        and ``group_index`` kwargs must still be forwarded to
+        ``npu_swiglu_group_quant`` after the patch — only ``glu_alpha``
+        and ``glu_bias`` are removed."""
+        _module, stubs = _load_patch_module(monkeypatch)
+        torch_mod = stubs["torch_mod"]
+        swiglu_calls, _result, shared_experts, evts = _run_w4a8mxfp_forward(stubs)
+
+        assert len(swiglu_calls) == 1
+        kwargs = swiglu_calls[0]
+
+        # Clamp value must come from FusedMoEEvents.swiglu_limit.
+        assert kwargs.get("clamp_value") == 0.5, f"clamp_value was clobbered: {kwargs!r}"
+        assert kwargs.get("dst_type") == torch_mod.float8_e4m3fn, f"dst_type was clobbered: {kwargs!r}"
+        assert kwargs.get("quant_mode") == 2, f"quant_mode was clobbered: {kwargs!r}"
+        assert kwargs.get("topk_weight") is None
+        assert kwargs.get("group_index") is None
+
+        # The hidden_states tensor (output of gate_up_proj) is the first
+        # positional arg of npu_swiglu_group_quant.
+        args = stubs["torch_mod"].ops._C_ascend.npu_swiglu_group_quant.call_args[0]
+        assert args[0] is shared_experts.gate_up_proj.return_value[0]
+
+    # ------------------------------------------------------------------ #
+    # 4. Regression — W4A8MXFP still awaits before_dispatch etc.         #
+    # ------------------------------------------------------------------ #
+    def test_w4a8mxfp_branch_waits_for_unmodified_events(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The W4A8MXFP branch's event waits are NOT touched by the patch:
+        ``before_routed_experts`` (synchronous), ``before_dispatch``,
+        ``before_gmm2``, and ``before_combine`` must all still be awaited."""
+        _module, stubs = _load_patch_module(monkeypatch)
+        swiglu_calls, result, shared_experts, evts = _run_w4a8mxfp_forward(stubs)
+
+        waited = stubs["shared_stream"].waited_events
+        assert evts.before_routed_experts in waited, f"W4A8MXFP path must wait on before_routed_experts, got {waited!r}"
+        assert evts.before_dispatch in waited, (
+            f"W4A8MXFP path must still wait on before_dispatch for gate_up_proj overlap, got {waited!r}"
+        )
+        assert evts.before_gmm2 in waited, f"W4A8MXFP path must wait on before_gmm2, got {waited!r}"
+        assert evts.before_combine in waited, f"W4A8MXFP path must wait on before_combine, got {waited!r}"
+
+        # Final result is the down_proj's [0] output.
+        assert result is shared_experts.down_proj.return_value[0]
+        # gate_up_proj was invoked exactly once.
+        shared_experts.gate_up_proj.assert_called_once()
+        shared_experts.down_proj.assert_called_once()
+
+    # ------------------------------------------------------------------ #
+    # 5. Regression — int-quant branch still uses glu_alpha/glu_bias      #
+    # ------------------------------------------------------------------ #
+    def test_int_quant_branch_still_forwards_glu_alpha_and_glu_bias_to_dequant(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The W8A8/W4A8 int-quant branch is NOT touched by the patch —
+        ``npu_dequant_swiglu_quant(...)`` must still receive the
+        ``glu_alpha`` and ``glu_bias`` kwargs (forwarded from
+        ``fused_moe_evts.swiglu_alpha`` / ``swiglu_beta``)."""
+        _module, stubs = _load_patch_module(monkeypatch)
+        cls = stubs["AscendMoERunner"]
+        QuantType = stubs["QuantType"]
+        FusedMoEEvents = stubs["FusedMoEEvents"]
+
+        evts = FusedMoEEvents(
+            before_routed_experts=_Event("before_routed_experts"),
+            after_routed_experts=_Event("after_routed_experts"),
+            before_dispatch=_Event("before_dispatch"),
+            before_gmm2=_Event("before_gmm2"),
+            before_combine=_Event("before_combine"),
+            swiglu_limit=1.5,
+            swiglu_alpha=1.1,
+            swiglu_beta=0.3,
+        )
+
+        dequant_calls: list[Any] = []
+
+        def _dequant(*_args, **kwargs):
+            dequant_calls.append(kwargs)
+            return (MagicMock(name="qx_after_dequant"), MagicMock(name="scale_after_dequant"))
+
+        stubs["torch_mod"].ops._C_ascend.npu_dequant_swiglu_quant = MagicMock(side_effect=_dequant)
+
+        shared_experts = _make_int_quant_shared_experts()
+        mock_self = MagicMock()
+        mock_self._shared_experts = shared_experts
+        mock_self.quant_type = QuantType.W8A8
+        mock_self.multistream_overlap_shared_expert = False
+
+        cls._forward_shared_experts(mock_self, _Hidden(), evts)
+
+        assert len(dequant_calls) == 1, f"expected exactly one npu_dequant_swiglu_quant call, got {len(dequant_calls)}"
+        kwargs = dequant_calls[0]
+
+        # Int-quant branch is preserved: clamp_limit, glu_alpha, glu_bias
+        # must all still be forwarded from the FusedMoEEvents object.
+        assert kwargs.get("clamp_limit") == 1.5
+        assert kwargs.get("glu_alpha") == 1.1, (
+            f"int-quant branch unexpectedly lost glu_alpha forwarding; got {kwargs!r}"
+        )
+        assert kwargs.get("glu_bias") == 0.3, f"int-quant branch unexpectedly lost glu_bias forwarding; got {kwargs!r}"
+        assert kwargs.get("quant_mode") == 1
+        assert kwargs.get("swiglu_mode") == 1
+        assert kwargs.get("activate_left") is True
+
+        # Int-quant branch reads down_proj attributes only — never invokes
+        # them as callables.
+        shared_experts.down_proj.assert_not_called()
+        shared_experts.gate_up_proj.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    # 6. Early-exit when ``_shared_experts`` is None                      #
+    # ------------------------------------------------------------------ #
+    def test_returns_none_when_shared_experts_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When ``self._shared_experts`` is None the patched method must
+        return ``None`` immediately and must NOT touch any NPU streams.
+
+        The patch preserves this early-exit behaviour unchanged from the
+        upstream ``fused_moe.py``.
+        """
+        _module, stubs = _load_patch_module(monkeypatch)
+        cls = stubs["AscendMoERunner"]
+        FusedMoEEvents = stubs["FusedMoEEvents"]
+
+        mock_self = MagicMock()
+        mock_self._shared_experts = None
+
+        evts = FusedMoEEvents(
+            before_routed_experts=_Event("before_routed_experts"),
+            after_routed_experts=_Event("after_routed_experts"),
+            before_dispatch=_Event("before_dispatch"),
+            before_gmm2=_Event("before_gmm2"),
+            before_combine=_Event("before_combine"),
+        )
+
+        # Force moe_comm_type into a setting that triggers the trailing
+        # all-reduce — verify the early-exit still bypasses it.
+        stubs["extra_ctx"].moe_comm_type = stubs["MoECommType"].MC2
+
+        result = cls._forward_shared_experts(mock_self, _Hidden(), evts)
+
+        assert result is None
+        assert stubs["shared_stream"].waited_events == [], "early-exit path must not invoke wait_event on any stream"
+
+        vllm_distributed_mod = sys.modules["vllm.distributed"]
+        vllm_distributed_mod.tensor_model_parallel_all_reduce.assert_not_called()
+
+    # ------------------------------------------------------------------ #
+    # 7. Non-quantized ``else`` branch is byte-identical to upstream     #
+    # ------------------------------------------------------------------ #
+    def test_non_quantized_else_branch_is_byte_identical_to_upstream(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Sanity check: the patch does NOT touch the non-quantized ``else``
+        branch. The branch must wait on ``before_routed_experts``,
+        ``before_dispatch`` (NOT before_gmm2), and ``before_combine`` —
+        exactly as the upstream code does."""
+        _module, stubs = _load_patch_module(monkeypatch)
+        cls = stubs["AscendMoERunner"]
+        QuantType = stubs["QuantType"]
+        FusedMoEEvents = stubs["FusedMoEEvents"]
+
+        before_routed = _Event("before_routed_experts")
+        before_dispatch = _Event("before_dispatch")
+        before_combine = _Event("before_combine")
+        before_gmm2 = _Event("before_gmm2")
+        evts = FusedMoEEvents(
+            before_routed_experts=before_routed,
+            after_routed_experts=_Event("after_routed_experts"),
+            before_dispatch=before_dispatch,
+            before_gmm2=before_gmm2,
+            before_combine=before_combine,
+        )
+
+        mock_self = MagicMock()
+        mock_self._shared_experts = _make_unquantized_shared_experts()
+        mock_self.quant_type = QuantType.NONE
+        mock_self.multistream_overlap_shared_expert = False
+        mock_self._shared_experts_part1 = MagicMock(return_value="p1")
+        mock_self._shared_experts_part2 = MagicMock(return_value="p2")
+
+        hidden = _Hidden()
+        result = cls._forward_shared_experts(mock_self, hidden, evts)
+
+        waited = stubs["shared_stream"].waited_events
+        # The upstream code uses ``before_dispatch`` here — this is a
+        # regression guard so any future patch "fix" on this line is
+        # immediately caught.
+        assert before_routed in waited
+        assert before_dispatch in waited, (
+            f"non-quantized branch must still wait on before_dispatch (upstream behaviour): {waited!r}"
+        )
+        assert before_combine in waited
+        assert before_gmm2 not in waited
+
+        mock_self._shared_experts_part1.assert_called_once_with(hidden)
+        mock_self._shared_experts_part2.assert_called_once_with(hidden, "p1")
+        assert result == "p2"
+
+        # ALLGATHER context (default) means the all-reduce is NOT applied.
+        vllm_distributed_mod = sys.modules["vllm.distributed"]
+        vllm_distributed_mod.tensor_model_parallel_all_reduce.assert_not_called()


### PR DESCRIPTION
## Summary

Add unit tests for the 4 A5-specific patch files introduced in PR #1893.

## Test Files

| Test File | Tests | Coverage |
|-----------|-------|----------|
| `tests/patch/platform/test_patch_vllm_registry.py` | 3 | `_run_in_subprocess` override |
| `tests/patch/platform/test_patch_vllm_ascend_utils.py` | 8 | `setup_ascend_local_comm_res` override |
| `tests/patch/worker/test_patch_deepseek_v4_dspark.py` | 5 | DSpark `load_weights` override |
| `tests/patch/worker/test_patch_fused_moe.py` | 7 | `_forward_shared_experts` MoE optimization |

**Total: 23 test cases**

## Design

- Uses `importlib.util.spec_from_file_location` for isolated module loading
- `sys.modules` stubbing via `monkeypatch.setitem` for external dependencies
- `MagicMock` for all external dependencies (torch, torch_npu, vllm, vllm_ascend)
- No hardware dependencies needed

## Verification

```bash
pytest tests/patch/ -v
```
