### PR TITLE
[BugFix] Report KV wait-timeout aborts as HTTP 504

### DIFF
--- a/ascend_vllm/patch/platform/patch_generate_base_serving.py
+++ b/ascend_vllm/patch/platform/patch_generate_base_serving.py
@@ -4,11 +4,16 @@
 from __future__ import annotations
 
 import functools
+from http import HTTPStatus
 from typing import Any
 
 from vllm.entrypoints.generate.base.serving import GenerateBaseServing
 from vllm.entrypoints.openai.engine.protocol import GenerationError
 from vllm.logger import init_logger
+
+from ascend_vllm.patch.platform.patch_scheduler import (
+    _VLLM_ABORT_WAITING_TIMEOUT_MSG,
+)
 
 logger = init_logger("vllm.ascend_vllm.patch.platform.patch_generate_base_serving")
 
@@ -41,7 +46,16 @@ def _patch_raise_if_error() -> None:
             request_id,
             message,
         )
-        raise GenerationError(message)
+
+        err = GenerationError(message)
+        # The decode node kept this request queued past
+        # VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT and the producer has
+        # force-freed its remote KV. Surface it as a 504 Gateway Timeout
+        # (retryable upstream timeout) instead of a generic 500 so callers
+        # can distinguish this scenario and retry.
+        if message == _VLLM_ABORT_WAITING_TIMEOUT_MSG:
+            err.status_code = HTTPStatus.GATEWAY_TIMEOUT
+        raise err
 
     setattr(patched_raise_if_error, _PATCH_MARKER, True)
     GenerateBaseServing._raise_if_error = patched_raise_if_error

--- a/ascend_vllm/patch/platform/patch_recompute_scheduler.py
+++ b/ascend_vllm/patch/platform/patch_recompute_scheduler.py
@@ -46,7 +46,7 @@ _KV_FAILURE_PATCH_MARKER = "_modelarts_kv_load_failure_recompute_scheduler_patch
 _FAILED_REQUEST_IDS_ATTR = "_modelarts_kv_load_failed_request_ids"
 _MISSING = object()
 _KV_LOAD_FAILURE_MSG = "KV cache load failed for one or more remote blocks. The request can be retried."
-_VLLM_ABORT_WAITING_TIMEOUT_MSG = "KV cache load failed for one or more remote blocks expired. The request can be retried."
+_VLLM_ABORT_WAITING_TIMEOUT_MSG = "Abort for kvcache waiting timeout. The request can be retried."
 
 
 def _patch_schedule(self, throttle_prefills: bool = False) -> RecomputeSchedulerOutput:

--- a/ascend_vllm/patch/platform/patch_scheduler.py
+++ b/ascend_vllm/patch/platform/patch_scheduler.py
@@ -34,7 +34,7 @@ _MISSING = object()
 _VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT_COEFFICIENT = 0.95
 _VLLM_REQUEST_SCHEDULE_WAITING_TIMEOUT = envs.VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT * _VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT_COEFFICIENT
 _KV_LOAD_FAILURE_MSG = "KV cache load failed for one or more remote blocks. The request can be retried."
-_VLLM_ABORT_WAITING_TIMEOUT_MSG = "KV cache load failed for one or more remote blocks expired. The request can be retried."
+_VLLM_ABORT_WAITING_TIMEOUT_MSG = "Abort for kvcache waiting timeout. The request can be retried."
 
 
 def _fail_expired_waiting_requests(self) -> None:


### PR DESCRIPTION
## Description

The decode node now surfaces requests aborted for exceeding
VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT as 504 Gateway Timeout instead of a
generic 500, so callers can distinguish and retry. Stop reason reworded
and shared with both scheduler patches to keep the mapping in sync.

## Type of Change

<!-- Mark the relevant option with an x -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/formatting change
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
