### PR TITLE
[Bugfix]: keep triton recovered-sampling path and clamp tokens to >=0

### DIFF
--- a/ascend_vllm/patch/worker/patch_rejection_sampler.py
+++ b/ascend_vllm/patch/worker/patch_rejection_sampler.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import torch
 
 _PATCH_APPLIED = False
-_PATCH_MARKER = "_modelarts_recovered_tokens_always_torch"
+_PATCH_MARKER = "_modelarts_recovered_tokens_clamped"
 
 
 def apply_patch() -> None:
-    """Route spec-decode recovered-token sampling through torch ops.
+    """Clamp spec-decode recovered tokens to >= 0 after the triton producer.
 
     ModelArts-layer override of
     ``vllm_ascend.sample.rejection_sampler.sample_recovered_tokens``.
@@ -20,16 +20,22 @@ def apply_patch() -> None:
     all-``-1`` empty output row -> no tokens appended -> PD-decode hang
     ("Avg generation throughput: 0.0").
 
-    The torch ops path is structurally immune: q==0/isinf columns are clamped
-    to a finite floor and a single whole-row ``torch.argmax`` always returns a
-    valid vocab index (>= 0), even when the whole row degenerates. This patch
-    therefore forces recovered sampling through the torch ops unconditionally
-    (regardless of HAS_TRITON). The triton random/greedy kernels still consume
-    the result afterwards, so no ``-1`` can reach output_token_ids.
+    Instead of re-routing recovered sampling through torch ops (which is
+    ~O(num_tokens x vocab) over the full row), this patch keeps the pristine
+    producer -- the triton kernel fast path under HAS_TRITON, the torch ops
+    path otherwise -- and only clamps the returned token ids to >= 0 (an
+    O(num_tokens) int elementwise, negligible next to the sampling itself).
+    Clamping makes the ``-1`` sentinel structurally inexpressible downstream
+    regardless of its origin (a degenerate row, or a buffer slot the kernel
+    left untouched): every negative value becomes 0, which is exactly the
+    token the torch path would also fall back to for a fully-degenerate row
+    (whole-row argmax over the clamped floor -> column 0). Healthy rows pass
+    through unchanged (no-op).
 
     The function is rebound on the ``vllm_ascend.sample.rejection_sampler``
     module because ``rejection_sample`` (same module) resolves the bare global
-    ``sample_recovered_tokens`` at call time.
+    ``sample_recovered_tokens`` at call time. The original function is captured
+    before the rebind and called as the fast-path producer.
     """
 
     global _PATCH_APPLIED
@@ -43,7 +49,7 @@ def apply_patch() -> None:
         _PATCH_APPLIED = True
         return
 
-    def sample_recovered_tokens_always_torch(
+    def sample_recovered_tokens_clamped(
         max_spec_len: int,
         num_draft_tokens: list[int],
         cu_num_draft_tokens: torch.Tensor,
@@ -57,61 +63,31 @@ def apply_patch() -> None:
         global_vocab_size: int | None = None,
         enable_reduce_sampling: bool = False,
     ) -> torch.Tensor:
-        batch_size = len(num_draft_tokens)
-        vocab_size = target_probs.shape[-1]
-
-        # Per-request normalization noise. Drawn again (with the request RNG)
-        # for rows that actually have draft tokens; other rows keep the bulk
-        # fill because their recovered value is never consumed.
-        q = torch.empty(
-            (batch_size, vocab_size),
-            dtype=torch.float32,
-            device=device,
+        # Delegate to the pristine producer: triton kernel under HAS_TRITON
+        # (torch ops otherwise), preserving the fast-path sampling performance.
+        recovered_token_ids = original(
+            max_spec_len,
+            num_draft_tokens,
+            cu_num_draft_tokens,
+            draft_token_ids,
+            draft_probs,
+            target_probs,
+            sampling_metadata,
+            device,
+            use_block_verify=use_block_verify,
+            target_indices=target_indices,
+            global_vocab_size=global_vocab_size,
+            enable_reduce_sampling=enable_reduce_sampling,
         )
-        q.exponential_()
-
-        num_draft_tensor = torch.tensor(num_draft_tokens, pin_memory=True).to(device, non_blocking=True)
-        has_draft_mask = num_draft_tensor > 0
-
-        for i, generator in sampling_metadata.generators.items():
-            temp_q = torch.empty_like(q[i])
-            temp_q.exponential_(generator=generator)
-            q[i] = torch.where(has_draft_mask[i], temp_q, q[i])
-
-        recovered_token_ids = torch.empty_like(draft_token_ids)
-        if use_block_verify:
-            rejection_sampler_module.sample_recovered_tokens_blockwise_pytorch(
-                recovered_token_ids,
-                cu_num_draft_tokens,
-                draft_token_ids,
-                draft_probs,
-                target_probs,
-                q,
-                vocab_size,
-                IS_NGRAM=draft_probs is None,
-                target_indices=target_indices,
-                enable_reduce_sampling=enable_reduce_sampling,
-            )
-        else:
-            rejection_sampler_module.sample_recovered_tokens_pytorch(
-                recovered_token_ids,
-                cu_num_draft_tokens,
-                draft_token_ids,
-                draft_probs,
-                target_probs,
-                q,
-                vocab_size,
-                IS_NGRAM=draft_probs is None,
-                target_indices=target_indices,
-                enable_reduce_sampling=enable_reduce_sampling,
-            )
+        # Belt: no -1 may reach the triton random/greedy consumer kernels.
+        recovered_token_ids.clamp_min_(0)
         return recovered_token_ids
 
-    sample_recovered_tokens_always_torch.__name__ = original.__name__
-    sample_recovered_tokens_always_torch.__doc__ = original.__doc__
-    setattr(sample_recovered_tokens_always_torch, _PATCH_MARKER, True)
+    sample_recovered_tokens_clamped.__name__ = original.__name__
+    sample_recovered_tokens_clamped.__doc__ = original.__doc__
+    setattr(sample_recovered_tokens_clamped, _PATCH_MARKER, True)
 
-    rejection_sampler_module.sample_recovered_tokens = sample_recovered_tokens_always_torch
+    rejection_sampler_module.sample_recovered_tokens = sample_recovered_tokens_clamped
     _PATCH_APPLIED = True
 
 


### PR DESCRIPTION
fix(rejection-sampler): keep triton recovered-sampling path and clamp tokens to >=0

## Description

<!-- Briefly describe what this PR does -->

## Type of Change

<!-- Mark the relevant option with an x -->

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/formatting change
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement
- [ ] ✅ Test addition/update

## How Has This Been Tested?

<!-- Describe the tests you ran to verify your changes -->

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->
